### PR TITLE
Feat#21

### DIFF
--- a/src/database/entities/user/user.entity.ts
+++ b/src/database/entities/user/user.entity.ts
@@ -1,9 +1,11 @@
+import { Max, Min } from 'class-validator';
 import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
   UpdateDateColumn,
+  Unique,
 } from 'typeorm';
 
 @Entity('user')
@@ -14,6 +16,9 @@ export class User {
   @Column({ type: 'varchar', length: 100 })
   email: string;
 
+  @Min(5)
+  @Max(20)
+  @Unique(['nickname'])
   @Column({ type: 'varchar', length: 50 })
   nickname: string;
 

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -22,7 +22,6 @@ import {
   ApiLogoutResponse,
   ApiRefreshResponse,
   ApiUnauthorizedResponse,
-  ApiValidateResponse,
 } from 'src/common/swagger';
 import {
   LoginRequestDto,
@@ -30,7 +29,6 @@ import {
   LoginResponseDto,
   LogoutResponseDto,
   RefreshTokenResponseDto,
-  ValidateResponseDto,
 } from './dto';
 import { ErrorResponseDto } from 'src/common/swagger/dto/error-response.dto';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
@@ -176,6 +174,7 @@ export class AuthController {
         message: 'Login successful',
         data: {
           access_token: access_token,
+          refresh_token: refresh_token, // Test용
           user: {
             id: user.id,
             email: user.email,

--- a/src/modules/user/dto/requests/update-nickname.dto.ts
+++ b/src/modules/user/dto/requests/update-nickname.dto.ts
@@ -1,10 +1,24 @@
 import { ApiProperty, ApiTags } from '@nestjs/swagger';
+import {
+  IsNotEmpty,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 
 @ApiTags('user')
 export class UpdateNicknameRequestDto {
   @ApiProperty({
     description: '사용자 닉네임',
     example: '승수',
+  })
+  @IsString({ message: '닉네임은 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '닉네임은 필수 입력값입니다.' })
+  @MinLength(5, { message: '닉네임은 최소 5자 이상이어야 합니다.' })
+  @MaxLength(20, { message: '닉네임은 최대 20자까지 가능합니다.' })
+  @Matches(/^[가-힣a-zA-Z0-9\s]+$/, {
+    message: '닉네임은 한글, 영문, 숫자, 공백만 사용 가능합니다.',
   })
   nickname: string;
 }

--- a/src/modules/user/dto/responses/update-nickname.dto.ts
+++ b/src/modules/user/dto/responses/update-nickname.dto.ts
@@ -2,10 +2,22 @@ import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateNicknameDataDto {
   @ApiProperty({
+    description: '유저 ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  id: string;
+
+  @ApiProperty({
     description: '업데이트된 닉네임',
     example: '새로운닉네임',
   })
   nickname: string;
+
+  @ApiProperty({
+    description: '업데이트된 시간',
+    example: '2025-07-01T10:00:00.000Z',
+  })
+  updated_at: Date;
 }
 
 export class UpdateNicknameResponseDto {

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,4 +1,13 @@
-import { Body, Controller, Delete, Get, Patch } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  HttpStatus,
+  Patch,
+  UseGuards,
+} from '@nestjs/common';
 import { UserService } from './user.service';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
@@ -13,12 +22,36 @@ import {
   UpdateNicknameRequestDto,
   UpdateNicknameResponseDto,
 } from './dto';
+import { User } from '../auth/decorators/user.decorator';
+import { JwtAuthGuard } from '../auth/guards';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 @ApiTags('user')
 @ApiBearerAuth()
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
+
+  @Patch('nickname')
+  @ApiOperation({ summary: '사용자 닉네임 수정' })
+  @ApiUpdateNicknameResponse()
+  @ApiCommonErrorResponses()
+  @UseGuards(JwtAuthGuard)
+  async updateNickname(
+    @User() user: any,
+    @Body() updateNicknameRequestDto: UpdateNicknameRequestDto,
+  ): Promise<UpdateNicknameResponseDto> {
+    try {
+      const { nickname } = updateNicknameRequestDto;
+
+      return await this.userService.updateNickname(user.id, nickname);
+    } catch (error) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest(error.message),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
 
   @Get('me')
   @ApiOperation({ summary: '사용자 정보 조회' })
@@ -35,24 +68,6 @@ export class UserController {
         nickname: '승수',
         profile_image: 'https://cdn.../profile.png',
         created_at: '2025-07-01T10:00:00.000Z',
-      },
-    };
-
-    return mockData;
-  }
-
-  @Patch('nickname')
-  @ApiOperation({ summary: '사용자 닉네임 수정' })
-  @ApiUpdateNicknameResponse()
-  @ApiCommonErrorResponses()
-  async updateNickname(
-    @Body() updateNicknameRequestDto: UpdateNicknameRequestDto,
-  ): Promise<UpdateNicknameResponseDto> {
-    const mockData: UpdateNicknameResponseDto = {
-      success: true,
-      message: 'Nickname updated successfully.',
-      data: {
-        nickname: updateNicknameRequestDto.nickname,
       },
     };
 

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from 'src/database/entities/user/user.entity';
+import { UserRepository } from './user.repository';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([User])],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [UserService, UserRepository],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
 import { User } from '../../database/entities/user/user.entity';
 
 @Injectable()
@@ -24,10 +24,22 @@ export class UserRepository {
     return this.userRepository.save(user);
   }
 
-  // 유저 조회 from JWTstrategy, RefreshStrategy
+  // 유저 조회 from JWTstrategy, RefreshStrategy ...
   async findUserById(userId: string): Promise<User | null> {
     return this.userRepository.findOne({
       where: { id: userId },
     });
+  }
+
+  // 유저 닉네임 중복 검사 (자신 제외)
+  async findByNicknameExcludeSelf(nickname: string, userId: string) {
+    return this.userRepository.findOne({
+      where: { nickname, id: Not(userId) },
+    });
+  }
+
+  // 유저 닉네임 수정
+  async updateUser(userId: string, nickname: string) {
+    return this.userRepository.update({ id: userId }, { nickname });
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -1,4 +1,93 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { UserRepository } from './user.repository';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 @Injectable()
-export class UserService {}
+export class UserService {
+  constructor(private readonly userRepository: UserRepository) {}
+
+  async updateNickname(userId: string, nickname: string) {
+    // 1. 닉네임 유효성 검사
+    await this.validateNickname(nickname);
+
+    // 2. 닉네임 중복 검사
+    const existingNickname =
+      await this.userRepository.findByNicknameExcludeSelf(nickname, userId);
+
+    if (existingNickname) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest('이미 사용 중인 닉네임입니다.'),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 3. 닉네임 수정
+    await this.userRepository.updateUser(userId, nickname);
+
+    // 4. 수정된 유저 정보 조회
+    const updatedUser = await this.userRepository.findUserById(userId);
+
+    if (!updatedUser) {
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError('Failed to update nickname'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+
+    // 5. 수정 결과 반환
+    return {
+      success: true,
+      message: 'Nickname updated successfully.',
+      data: {
+        id: updatedUser.id,
+        nickname: updatedUser.nickname,
+        updated_at: updatedUser.updated_at,
+      },
+    };
+  }
+
+  private async validateNickname(nickname: string) {
+    // 추가적인 비즈니스 로직 검증
+    if (nickname.trim() !== nickname) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest(
+          '닉네임 앞뒤에 공백이 포함될 수 없습니다.',
+        ),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 금지된 단어 체크
+    const forbiddenWords = [
+      'admin',
+      'root',
+      'system',
+      '관리자',
+      'user',
+      'undefined',
+      'null',
+    ];
+    if (
+      forbiddenWords.some((word) =>
+        nickname.toLowerCase().includes(word.toLowerCase()),
+      )
+    ) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest(
+          '사용할 수 없는 단어가 포함되어 있습니다.',
+        ),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    // 연속된 동일 문자 체크
+    if (/(.)\1{3,}/.test(nickname)) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest(
+          '연속된 동일한 문자는 3개까지만 사용 가능합니다.',
+        ),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+}


### PR DESCRIPTION
# Nickname API 구현

## 개요
사용자 닉네임 변경 기능을 위한 API를 구현

## 주요 변경사항
### 1. API 엔드포인트 추가
- **PATCH** `/api/user/nickname` 엔드포인트 구현
- JWT 인증을 통한 사용자 식별

### 2. 핵심 기능
- 닉네임 중복 검사
- 닉네임 유효성 검증
- 표준화된 응답 형식 적용

### 3. 아키텍처 구성
- Controller: API 엔드포인트 및 인증처리
- Service: 비즈니스 로직 및 검증
- Repository: 데이터베이스 작업
- DTO: 요청/응답 데이터 구조 정의