### PR TITLE
Feat#22

### DIFF
--- a/src/app.controller.spec.ts
+++ b/src/app.controller.spec.ts
@@ -15,8 +15,11 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return health check response', () => {
+      const result = appController.getHello();
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('서버가 정상 동작 중입니다.');
+      expect(result.data).toBe('Hello World!');
     });
   });
 });

--- a/src/common/utils/error-response.util.ts
+++ b/src/common/utils/error-response.util.ts
@@ -14,6 +14,10 @@ export class ErrorResponseUtil {
     return this.create(HttpStatus.UNAUTHORIZED, message || 'Unauthorized');
   }
 
+  static forbidden(message?: string) {
+    return this.create(HttpStatus.FORBIDDEN, message || 'Forbidden');
+  }
+
   static notFound(message?: string) {
     return this.create(HttpStatus.NOT_FOUND, message || 'Not found');
   }

--- a/src/database/entities/user/user.entity.ts
+++ b/src/database/entities/user/user.entity.ts
@@ -1,4 +1,4 @@
-import { Max, Min } from 'class-validator';
+import { Length } from 'class-validator';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -9,6 +9,7 @@ import {
 } from 'typeorm';
 
 @Entity('user')
+@Unique(['nickname'])
 export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -16,10 +17,8 @@ export class User {
   @Column({ type: 'varchar', length: 100 })
   email: string;
 
-  @Min(5)
-  @Max(20)
-  @Unique(['nickname'])
   @Column({ type: 'varchar', length: 50 })
+  @Length(5, 20)
   nickname: string;
 
   @Column({ type: 'varchar', length: 255, nullable: true })
@@ -31,6 +30,17 @@ export class User {
   @UpdateDateColumn({ name: 'updated_at' })
   updated_at: Date;
 
-  @Column({ type: 'boolean', default: false })
+  @Column({ type: 'boolean', default: false, name: 'deleted' })
   deleted: boolean;
+
+  @Column({ type: 'timestamp', name: 'deleted_at', nullable: true })
+  deleted_at: Date | null;
+
+  @Column({
+    type: 'varchar',
+    length: 255,
+    name: 'delete_reason',
+    nullable: true,
+  })
+  delete_reason: string | null;
 }

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,6 +1,5 @@
 import {
   Controller,
-  Get,
   Post,
   Body,
   Param,
@@ -8,10 +7,9 @@ import {
   Logger,
   HttpException,
   HttpStatus,
-  Req,
   UseGuards,
 } from '@nestjs/common';
-import { Response, Request } from 'express';
+import { Response } from 'express';
 import { AuthService } from './auth.service';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
@@ -184,9 +182,18 @@ export class AuthController {
         },
       };
     } catch (error) {
+      // HttpException은 그대로 전달 (상태 코드 유지)
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      // 예상치 못한 에러는 500 Internal Server Error로 변환
+      this.logger.error('❌ 로그인 처리 중 예상치 못한 에러 발생:', error);
       throw new HttpException(
-        ErrorResponseUtil.unauthorized('Authentication failed'),
-        HttpStatus.UNAUTHORIZED,
+        ErrorResponseUtil.internalServerError(
+          'Login failed due to internal server error',
+        ),
+        HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
   }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -102,6 +102,13 @@ export class AuthService {
       const existingUser = await this.authRepository.findBySocialId(socialId);
 
       if (existingUser) {
+        // 탈퇴한 사용자 차단
+        if (existingUser.user.deleted) {
+          throw new HttpException(
+            ErrorResponseUtil.forbidden('Account has been deactivated'),
+            HttpStatus.FORBIDDEN,
+          );
+        }
         return {
           id: existingUser.user_id,
           email: existingUser.user.email,
@@ -132,6 +139,11 @@ export class AuthService {
         provider: newAuth.provider,
       };
     } catch (error) {
+      // HttpException은 그대로 전달
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
       throw new HttpException(
         ErrorResponseUtil.internalServerError('Failed to process user data'),
         HttpStatus.INTERNAL_SERVER_ERROR,

--- a/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/src/modules/auth/guards/jwt-auth.guard.ts
@@ -58,6 +58,15 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
     // 기타 에러 처리
     if (err) {
       this.logger.error('❌ JwtAuthGuard 에러 발생:', err.message);
+
+      // 탈퇴한 사용자 에러 처리 (403 Forbidden)
+      if (err.status === HttpStatus.FORBIDDEN) {
+        throw new HttpException(
+          ErrorResponseUtil.forbidden('Account has been deactivated'),
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
       throw new HttpException(
         ErrorResponseUtil.unauthorized('Authentication failed'),
         HttpStatus.UNAUTHORIZED,

--- a/src/modules/auth/guards/refresh.guard.ts
+++ b/src/modules/auth/guards/refresh.guard.ts
@@ -14,6 +14,14 @@ export class RefreshGuard extends AuthGuard('refresh') {
 
     if (err) {
       this.logger.error('❌ RefreshGuard 에러 발생:', err.message);
+
+      if (err.status === HttpStatus.FORBIDDEN) {
+        throw new HttpException(
+          ErrorResponseUtil.forbidden('Account has been deactivated'),
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
       throw new HttpException(
         ErrorResponseUtil.unauthorized('Invalid refresh token'),
         HttpStatus.UNAUTHORIZED,

--- a/src/modules/auth/strategies/jwt.strategy.ts
+++ b/src/modules/auth/strategies/jwt.strategy.ts
@@ -32,6 +32,14 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
         );
       }
 
+      // 탈퇴한 사용자 차단
+      if (user.deleted) {
+        throw new HttpException(
+          ErrorResponseUtil.forbidden('Account has been deactivated'),
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
       return {
         id: user.id,
         email: user.email,

--- a/src/modules/auth/strategies/refresh.strategy.ts
+++ b/src/modules/auth/strategies/refresh.strategy.ts
@@ -63,6 +63,14 @@ export class RefreshStrategy extends PassportStrategy(Strategy, 'refresh') {
         );
       }
 
+      // 탈퇴한 사용자 차단
+      if (user.deleted) {
+        throw new HttpException(
+          ErrorResponseUtil.forbidden('Account has been deactivated'),
+          HttpStatus.FORBIDDEN,
+        );
+      }
+
       return {
         id: accessPayload.userId,
         email: user.email,

--- a/src/modules/user/dto/index.ts
+++ b/src/modules/user/dto/index.ts
@@ -1,5 +1,6 @@
 // Requests
 export * from './requests/update-nickname.dto';
+export * from './requests/delete-user.dto';
 
 // Responses
 export * from './responses/get-user.dto';

--- a/src/modules/user/dto/requests/delete-user.dto.ts
+++ b/src/modules/user/dto/requests/delete-user.dto.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class DeleteUserRequestDto {
+  @ApiProperty({
+    description: '탈퇴 사유',
+    example: '자주 이용하지 않아요.',
+  })
+  @IsString({ message: '탈퇴 사유는 문자열이어야 합니다.' })
+  @IsNotEmpty({ message: '탈퇴 사유는 필수 입력값입니다.' })
+  @MaxLength(100, { message: '탈퇴 사유는 최대 100자까지 가능합니다.' })
+  delete_reason: string;
+}

--- a/src/modules/user/dto/responses/delete-user.dto.ts
+++ b/src/modules/user/dto/responses/delete-user.dto.ts
@@ -1,5 +1,25 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export class DeleteUserDataDto {
+  @ApiProperty({
+    description: '사용자 ID',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  user_id: string;
+
+  @ApiProperty({
+    description: '탈퇴 처리된 시간',
+    example: '2024-08-17T16:30:00.000Z',
+  })
+  deactivated_at: string | null;
+
+  @ApiProperty({
+    description: '계정 상태',
+    example: 'deactivated | already_deactivated',
+  })
+  status: string;
+}
+
 export class DeleteUserResponseDto {
   @ApiProperty({
     description: '응답 성공 여부',
@@ -9,7 +29,13 @@ export class DeleteUserResponseDto {
 
   @ApiProperty({
     description: '응답 메시지',
-    example: 'User account deleted successfully.',
+    example: 'Account deactivated successfully.',
   })
   message: string;
+
+  @ApiProperty({
+    description: '응답 데이터',
+    type: DeleteUserDataDto,
+  })
+  data: DeleteUserDataDto;
 }

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -1,20 +1,136 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 describe('UserController', () => {
   let controller: UserController;
+  let userService: jest.Mocked<UserService>;
+
+  const mockUser = {
+    id: 'user-123',
+    email: 'test@example.com',
+    nickname: 'testuser',
+  };
+
+  const mockDeleteUserRequest = {
+    delete_reason: 'Personal reason',
+  };
+
+  const mockDeleteUserResponse = {
+    success: true,
+    message: 'Account deactivated successfully.',
+    data: {
+      user_id: 'user-123',
+      deactivated_at: new Date().toISOString(),
+      status: 'deactivated',
+    },
+  };
 
   beforeEach(async () => {
+    const mockUserService = {
+      deleteUser: jest.fn(),
+      getUser: jest.fn(),
+      updateNickname: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [UserController],
-      providers: [UserService],
+      providers: [
+        {
+          provide: UserService,
+          useValue: mockUserService,
+        },
+      ],
     }).compile();
 
     controller = module.get<UserController>(UserController);
+    userService = module.get(UserService);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('deleteUser', () => {
+    it('should successfully deactivate user account', async () => {
+      // Arrange
+      userService.deleteUser.mockResolvedValue(mockDeleteUserResponse);
+
+      // Act
+      const result = await controller.deleteUser(
+        mockUser,
+        mockDeleteUserRequest,
+      );
+
+      // Assert
+      expect(result).toEqual(mockDeleteUserResponse);
+      expect(userService.deleteUser).toHaveBeenCalledWith(
+        mockUser.id,
+        mockDeleteUserRequest.delete_reason,
+      );
+    });
+
+    it('should handle service errors and return bad request', async () => {
+      // Arrange
+      const serviceError = new HttpException(
+        ErrorResponseUtil.badRequest('Service error'),
+        HttpStatus.BAD_REQUEST,
+      );
+      userService.deleteUser.mockRejectedValue(serviceError);
+
+      // Act & Assert
+      await expect(
+        controller.deleteUser(mockUser, mockDeleteUserRequest),
+      ).rejects.toThrow(
+        new HttpException(
+          ErrorResponseUtil.badRequest(serviceError.message),
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
+      expect(userService.deleteUser).toHaveBeenCalledWith(
+        mockUser.id,
+        mockDeleteUserRequest.delete_reason,
+      );
+    });
+
+    it('should handle different error types from service', async () => {
+      // Arrange
+      const notFoundError = new HttpException(
+        ErrorResponseUtil.notFound('User not found'),
+        HttpStatus.NOT_FOUND,
+      );
+      userService.deleteUser.mockRejectedValue(notFoundError);
+
+      // Act & Assert
+      await expect(
+        controller.deleteUser(mockUser, mockDeleteUserRequest),
+      ).rejects.toThrow(
+        new HttpException(
+          ErrorResponseUtil.badRequest(notFoundError.message),
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
+    });
+
+    it('should handle internal server errors from service', async () => {
+      // Arrange
+      const internalError = new HttpException(
+        ErrorResponseUtil.internalServerError('Database error'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+      userService.deleteUser.mockRejectedValue(internalError);
+
+      // Act & Assert
+      await expect(
+        controller.deleteUser(mockUser, mockDeleteUserRequest),
+      ).rejects.toThrow(
+        new HttpException(
+          ErrorResponseUtil.badRequest(internalError.message),
+          HttpStatus.BAD_REQUEST,
+        ),
+      );
+    });
   });
 });

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -6,8 +6,10 @@ import {
   HttpException,
   HttpStatus,
   Patch,
+  Res,
   UseGuards,
 } from '@nestjs/common';
+import { Response } from 'express';
 import { UserService } from './user.service';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
@@ -17,6 +19,7 @@ import {
   ApiUpdateNicknameResponse,
 } from 'src/common/swagger';
 import {
+  DeleteUserRequestDto,
   DeleteUserResponseDto,
   GetUserResponseDto,
   UpdateNicknameRequestDto,
@@ -62,16 +65,30 @@ export class UserController {
     return await this.userService.getUser(user.id);
   }
 
-  @Delete()
+  @Delete('me')
   @ApiOperation({ summary: '사용자 탈퇴' })
   @ApiDeleteUserResponse()
   @ApiCommonErrorResponses()
-  async deleteUser(): Promise<DeleteUserResponseDto> {
-    const mockData: DeleteUserResponseDto = {
-      success: true,
-      message: 'User account deleted successfully.',
-    };
+  @UseGuards(JwtAuthGuard)
+  async deleteUser(
+    @User() user: any,
+    @Body() deleteUserRequestDto: DeleteUserRequestDto,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<DeleteUserResponseDto> {
+    const { delete_reason } = deleteUserRequestDto;
 
-    return mockData;
+    const result = await this.userService.deleteUser(user.id, delete_reason);
+
+    // 탈퇴 성공 시 refresh_token 쿠키 삭제
+    if (result.success && result.data.status === 'deactivated') {
+      res.clearCookie('refresh_token', {
+        httpOnly: false,
+        secure: false,
+        sameSite: 'lax',
+        path: '/',
+      });
+    }
+
+    return result;
   }
 }

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -42,4 +42,19 @@ export class UserRepository {
   async updateUser(userId: string, nickname: string) {
     return this.userRepository.update({ id: userId }, { nickname });
   }
+
+  // 삭제된 사용자 확인
+  async findDeletedUserById(userId: string): Promise<User | null> {
+    return this.userRepository.findOne({
+      where: { id: userId, deleted: true },
+    });
+  }
+
+  // 유저 삭제
+  async deleteUser(userId: string, delete_reason: string): Promise<void> {
+    await this.userRepository.update(
+      { id: userId },
+      { deleted: true, deleted_at: new Date(), delete_reason },
+    );
+  }
 }

--- a/src/modules/user/user.service.spec.ts
+++ b/src/modules/user/user.service.spec.ts
@@ -1,18 +1,180 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { UserRepository } from './user.repository';
+import { AuthRepository } from '../auth/auth.repository';
+import { DataSource } from 'typeorm';
+import { HttpException, HttpStatus } from '@nestjs/common';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
+import { User } from '../../database/entities/user/user.entity';
 
 describe('UserService', () => {
   let service: UserService;
+  let userRepository: jest.Mocked<UserRepository>;
+  let authRepository: jest.Mocked<AuthRepository>;
+  let dataSource: jest.Mocked<DataSource>;
+
+  const mockUser: User = {
+    id: 'user-123',
+    email: 'test@example.com',
+    nickname: 'testuser',
+    profile_image: 'https://example.com/image.jpg',
+    created_at: new Date(),
+    updated_at: new Date(),
+    deleted: false,
+    deleted_at: null,
+    delete_reason: null,
+  };
+
+  const mockDeletedUser: User = {
+    ...mockUser,
+    deleted: true,
+    deleted_at: new Date(),
+    delete_reason: 'Personal reason',
+  };
 
   beforeEach(async () => {
+    const mockUserRepository = {
+      findUserById: jest.fn(),
+      deleteUser: jest.fn(),
+    };
+
+    const mockAuthRepository = {
+      invalidateTokens: jest.fn(),
+    };
+
+    const mockDataSource = {
+      transaction: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        {
+          provide: UserRepository,
+          useValue: mockUserRepository,
+        },
+        {
+          provide: AuthRepository,
+          useValue: mockAuthRepository,
+        },
+        {
+          provide: DataSource,
+          useValue: mockDataSource,
+        },
+      ],
     }).compile();
 
     service = module.get<UserService>(UserService);
+    userRepository = module.get(UserRepository);
+    authRepository = module.get(AuthRepository);
+    dataSource = module.get(DataSource);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('deleteUser', () => {
+    it('should successfully deactivate user account', async () => {
+      // Arrange
+      const userId = 'user-123';
+      const deleteReason = 'Personal reason';
+
+      userRepository.findUserById.mockResolvedValue(mockUser);
+      (dataSource.transaction as jest.Mock).mockImplementation(
+        async (callback: any) => {
+          return await callback({
+            getRepository: jest.fn(),
+          });
+        },
+      );
+
+      // Act
+      const result = await service.deleteUser(userId, deleteReason);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Account deactivated successfully.');
+      expect(result.data.user_id).toBe(userId);
+      expect(result.data.status).toBe('deactivated');
+      expect(userRepository.findUserById).toHaveBeenCalledWith(userId);
+      expect(dataSource.transaction).toHaveBeenCalled();
+    });
+
+    it('should return already deactivated status for deleted user', async () => {
+      // Arrange
+      const userId = 'user-123';
+      const deleteReason = 'Personal reason';
+
+      userRepository.findUserById.mockResolvedValue(mockDeletedUser);
+
+      // Act
+      const result = await service.deleteUser(userId, deleteReason);
+
+      // Assert
+      expect(result.success).toBe(true);
+      expect(result.message).toBe('Account already deactivated.');
+      expect(result.data.status).toBe('already_deactivated');
+      expect(result.data.user_id).toBe(userId);
+      expect(userRepository.findUserById).toHaveBeenCalledWith(userId);
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should throw NotFoundException when user does not exist', async () => {
+      // Arrange
+      const userId = 'non-existent-user';
+      const deleteReason = 'Personal reason';
+
+      userRepository.findUserById.mockResolvedValue(null);
+
+      // Act & Assert
+      await expect(service.deleteUser(userId, deleteReason)).rejects.toThrow(
+        new HttpException(
+          ErrorResponseUtil.notFound('User not found'),
+          HttpStatus.NOT_FOUND,
+        ),
+      );
+      expect(userRepository.findUserById).toHaveBeenCalledWith(userId);
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
+
+    it('should handle transaction errors gracefully', async () => {
+      // Arrange
+      const userId = 'user-123';
+      const deleteReason = 'Personal reason';
+
+      userRepository.findUserById.mockResolvedValue(mockUser);
+      dataSource.transaction.mockRejectedValue(new Error('Transaction failed'));
+
+      // Act & Assert
+      await expect(service.deleteUser(userId, deleteReason)).rejects.toThrow(
+        new HttpException(
+          ErrorResponseUtil.internalServerError('Failed to deactivate account'),
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        ),
+      );
+      expect(userRepository.findUserById).toHaveBeenCalledWith(userId);
+      expect(dataSource.transaction).toHaveBeenCalled();
+    });
+
+    it('should rethrow HttpException errors', async () => {
+      // Arrange
+      const userId = 'user-123';
+      const deleteReason = 'Personal reason';
+
+      const customError = new HttpException(
+        ErrorResponseUtil.badRequest('Custom error'),
+        HttpStatus.BAD_REQUEST,
+      );
+
+      userRepository.findUserById.mockRejectedValue(customError);
+
+      // Act & Assert
+      await expect(service.deleteUser(userId, deleteReason)).rejects.toThrow(
+        customError,
+      );
+      expect(userRepository.findUserById).toHaveBeenCalledWith(userId);
+      expect(dataSource.transaction).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -2,12 +2,14 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { UserRepository } from './user.repository';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 import { AuthRepository } from '../auth/auth.repository';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class UserService {
   constructor(
     private readonly userRepository: UserRepository,
     private readonly authRepository: AuthRepository,
+    private readonly dataSource: DataSource,
   ) {}
 
   async updateNickname(userId: string, nickname: string) {
@@ -122,5 +124,59 @@ export class UserService {
         created_at: user.created_at.toISOString(),
       },
     };
+  }
+
+  async deleteUser(userId: string, delete_reason: string) {
+    try {
+      // 1. 유저 삭제 상태 확인
+      const user = await this.userRepository.findUserById(userId);
+
+      if (!user) {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('User not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (user.deleted) {
+        return {
+          success: true,
+          message: 'Account already deactivated.',
+          data: {
+            user_id: userId,
+            deactivated_at: user.deleted_at?.toISOString() || null,
+            status: 'already_deactivated',
+          },
+        };
+      }
+
+      // 2. 트랜잭션으로 탈퇴 처리
+      await this.dataSource.transaction(async (transactionalEntityManager) => {
+        // 2-1. 사용자 비활성화
+        await this.userRepository.deleteUser(userId, delete_reason);
+
+        // 2-2. 인증 정보 무효화
+        await this.authRepository.invalidateTokens(userId);
+      });
+
+      return {
+        success: true,
+        message: 'Account deactivated successfully.',
+        data: {
+          user_id: userId,
+          deactivated_at: new Date().toISOString(),
+          status: 'deactivated',
+        },
+      };
+    } catch (error) {
+      if (error instanceof HttpException) {
+        throw error;
+      }
+
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError('Failed to deactivate account'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 }


### PR DESCRIPTION
# 회원탈퇴 API 구현

## 주요 변경사항

### 1. 데이터베이스 구조 변경
- User 엔티티에 탈퇴 관련 필드 추가 (`deleted`, `deleted_at`, `delete_reason`)

### 2. 회원탈퇴 API 구현
- `DELETE /user/me` 엔드포인트 추가
- 탈퇴 처리 트랜잭션 및 토큰 무효화
- 탈퇴 완료 후 `refresh_token` 쿠키 자동 삭제

### 3. 보안 강화
- 탈퇴한 사용자 JWT/Refresh 토큰 차단
- 인증 가드에서 403 Forbidden 에러 처리
- 탈퇴한 사용자 로그인 시도 차단

### 4. 에러 처리 표준화
- `ErrorResponseUtil.forbidden()` 메서드 추가
- 표준화된 에러 응답 형식 적용