### PR TITLE
feat: 관심종목 폴더 삭제 API 구현

### DIFF
--- a/src/modules/favorite/dto/requests/folder/delete-favorite-folder.dto.ts
+++ b/src/modules/favorite/dto/requests/folder/delete-favorite-folder.dto.ts
@@ -1,12 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNumber, IsPositive } from 'class-validator';
+import { IsNumberString, IsPositive } from 'class-validator';
 
 export class DeleteFavoriteFolderParamDto {
   @ApiProperty({
     description: '관심종목 폴더 ID',
     example: 1,
   })
-  @IsNumber()
+  @IsNumberString()
   @IsPositive()
-  favorite_id: number;
+  favorite_id: string;
 }

--- a/src/modules/favorite/favorite-folder.controller.ts
+++ b/src/modules/favorite/favorite-folder.controller.ts
@@ -14,11 +14,11 @@ import {
   GetFavoriteFoldersResponseDto,
   CreateFavoriteFolderResponseDto,
   CreateFavoriteFolderDto,
-  DeleteFavoriteFolderParamDto,
   DeleteFavoriteFolderResponseDto,
   UpdateFavoriteFolderParamsDto,
   UpdateFavoriteFolderBodyDto,
   UpdateFavoriteFolderResponseDto,
+  DeleteFavoriteFolderParamDto,
 } from './dto';
 import {
   ApiCommonErrorResponses,
@@ -57,22 +57,25 @@ export class FavoriteFolderController {
     @Body() createFavoriteFolderDto: CreateFavoriteFolderDto,
     @User() user: any,
   ): Promise<CreateFavoriteFolderResponseDto> {
-    const { name } = createFavoriteFolderDto;
-
-    return await this.favoriteFolderService.createFavoriteFolder(name, user.id);
+    return await this.favoriteFolderService.createFavoriteFolder(
+      createFavoriteFolderDto.name,
+      user.id,
+    );
   }
 
   @Delete(':favorite_id')
   @ApiOperation({ summary: '관심종목 폴더 삭제' })
   @ApiDeleteFavoriteFolderResponse()
   @ApiCommonErrorResponsesWithNotFound()
+  @UseGuards(JwtAuthGuard)
   async deleteFavoriteFolder(
     @Param() deleteFavoriteFolderParamDto: DeleteFavoriteFolderParamDto,
+    @User() user: any,
   ): Promise<DeleteFavoriteFolderResponseDto> {
-    return {
-      success: true,
-      message: 'Favorite Folder deleted successfully.',
-    };
+    return await this.favoriteFolderService.deleteFavoriteFolder(
+      deleteFavoriteFolderParamDto.favorite_id,
+      user.id,
+    );
   }
 
   @Put(':favorite_id')

--- a/src/modules/favorite/favorite-folder.repository.ts
+++ b/src/modules/favorite/favorite-folder.repository.ts
@@ -49,4 +49,31 @@ export class FavoriteFolderRepository {
 
     return this.favoriteRepository.save(newFolder);
   }
+
+  // 폴더 ID 중복 조회
+  async findByFolderIdWithUserId(favoriteId: number, userId: string) {
+    return this.favoriteRepository.findOne({
+      where: { id: favoriteId, user_id: userId },
+    });
+  }
+
+  // 폴더 삭제
+  async deleteFavoriteFolder(favoriteId: number) {
+    return this.favoriteRepository.delete(favoriteId);
+  }
+
+  // 폴더 정렬 순서 조정
+  async updateSortOrder(userId: string, deletedSortOrder) {
+    await this.favoriteRepository
+      .createQueryBuilder()
+      .update(Favorite)
+      .set({
+        sort_order: () => 'sort_order -1',
+      })
+      .where('user_id = :userId AND sort_order > :deletedSortOrder', {
+        userId,
+        deletedSortOrder,
+      })
+      .execute();
+  }
 }

--- a/src/modules/favorite/favorite-folder.service.ts
+++ b/src/modules/favorite/favorite-folder.service.ts
@@ -74,4 +74,36 @@ export class FavoriteFolderService {
       },
     };
   }
+
+  async deleteFavoriteFolder(favorite_id: string, userId: string) {
+    const favoriteId = Number(favorite_id);
+
+    //1. 폴더 조회
+    const existingFolder =
+      await this.favoriteRepository.findByFolderIdWithUserId(
+        favoriteId,
+        userId,
+      );
+
+    if (!existingFolder) {
+      throw new HttpException(
+        ErrorResponseUtil.badRequest('폴더를 찾을 수 없습니다.'),
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+
+    const deletedSortOrder = existingFolder.sort_order;
+
+    //2-1. 폴더 삭제
+    await this.favoriteRepository.deleteFavoriteFolder(favoriteId);
+
+    //2-2. 폴더 삭제 후 정렬 순서 조정
+    await this.favoriteRepository.updateSortOrder(userId, deletedSortOrder);
+
+    //3. 리턴
+    return {
+      success: true,
+      message: 'Favorite Folder deleted successfully.',
+    };
+  }
 }


### PR DESCRIPTION
# 관심종목 폴더 삭제
## 주요 변경사항
### 1. 관심종목 폴더 삭제 API 구현
- `DELETE` `/api/favorites/{:favorite_id}` 엔드포인트 추가
- 폴더 삭제 후 sort_order 자동 재정렬 (1,2,4,5 -> 1,2,3,4)
