### PR TITLE
feat: 관심종목 폴더 편집 API 구현

### DIFF
--- a/src/modules/favorite/dto/requests/folder/update-favorite-folder.dto.ts
+++ b/src/modules/favorite/dto/requests/folder/update-favorite-folder.dto.ts
@@ -55,13 +55,3 @@ export class UpdateFavoriteFolderBodyDto {
   favorites: FavoriteItemDto[];
 }
 
-// Params DTO (경로 파라미터) - 필요시 사용
-export class UpdateFavoriteFolderParamsDto {
-  @ApiProperty({
-    description: '관심종목 폴더 ID',
-    example: 1,
-  })
-  @IsNumber()
-  @IsPositive()
-  id: number;
-}

--- a/src/modules/favorite/dto/responses/folder/update-favorite-folders.dto.ts
+++ b/src/modules/favorite/dto/responses/folder/update-favorite-folders.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { UpdateFavoriteFolderBodyDto } from '../../requests/folder/update-favorite-folder.dto';
+import { FavoriteItemDto } from '../../requests/folder/update-favorite-folder.dto';
 
 export class UpdateFavoriteFolderResponseDto {
   @ApiProperty({ description: '응답 성공 여부', example: true })
@@ -13,12 +13,12 @@ export class UpdateFavoriteFolderResponseDto {
 
   @ApiProperty({
     description: '수정된 관심종목 폴더 정보',
-    type: UpdateFavoriteFolderBodyDto,
+    type: FavoriteItemDto,
     example: {
       favorite_id: 1,
       name: '배당주 투자',
       sort_order: 1,
     },
   })
-  data: UpdateFavoriteFolderBodyDto;
+  data: FavoriteItemDto[];
 }

--- a/src/modules/favorite/favorite-folder.controller.ts
+++ b/src/modules/favorite/favorite-folder.controller.ts
@@ -15,7 +15,6 @@ import {
   CreateFavoriteFolderResponseDto,
   CreateFavoriteFolderDto,
   DeleteFavoriteFolderResponseDto,
-  UpdateFavoriteFolderParamsDto,
   UpdateFavoriteFolderBodyDto,
   UpdateFavoriteFolderResponseDto,
   DeleteFavoriteFolderParamDto,
@@ -78,18 +77,18 @@ export class FavoriteFolderController {
     );
   }
 
-  @Put(':favorite_id')
+  @Put()
   @ApiOperation({ summary: '관심종목 폴더 수정' })
   @ApiUpdateFavoriteFolderResponse()
   @ApiCommonErrorResponses()
+  @UseGuards(JwtAuthGuard)
   async updateFavoriteFolder(
-    @Param() updateFavoriteFolderParamDto: UpdateFavoriteFolderParamsDto,
     @Body() updateFavoriteFolderBodyDto: UpdateFavoriteFolderBodyDto,
+    @User() user: any,
   ): Promise<UpdateFavoriteFolderResponseDto> {
-    return {
-      success: true,
-      message: 'Favorite Folder updated successfully.',
-      data: updateFavoriteFolderBodyDto,
-    };
+    return await this.favoriteFolderService.updateFavoriteFolder(
+      updateFavoriteFolderBodyDto.favorites,
+      user.id,
+    );
   }
 }

--- a/src/modules/favorite/favorite-folder.repository.ts
+++ b/src/modules/favorite/favorite-folder.repository.ts
@@ -1,13 +1,16 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Favorite } from 'src/database/entities/favorite/favorite.entity';
-import { Repository, Transaction } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { FavoriteItemDto } from './dto';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 @Injectable()
 export class FavoriteFolderRepository {
   constructor(
     @InjectRepository(Favorite)
     private favoriteRepository: Repository<Favorite>,
+    private dataSource: DataSource,
   ) {}
 
   // 사용자의 관심종목 폴더 목록 조회
@@ -75,5 +78,69 @@ export class FavoriteFolderRepository {
         deletedSortOrder,
       })
       .execute();
+  }
+
+  // 폴더 이름 변경
+  async updateFavoriteFolderName(favoriteId: number, name: string) {
+    return this.favoriteRepository.update({ id: favoriteId }, { name });
+  }
+
+  // 폴더 정렬 순서 변경
+  async updateFavoriteFolderSortOrder(favoriteId: number, sort_order: number) {
+    return this.favoriteRepository.update({ id: favoriteId }, { sort_order });
+  }
+
+  async updateFavoriteFolderWithTransation(
+    favorites: FavoriteItemDto[],
+    userId: string,
+  ) {
+    return this.dataSource.transaction(async (manager) => {
+      // 1. 폴더 조회 및 검증
+      for (const favorite of favorites) {
+        const existingFolder = await manager.findOne(Favorite, {
+          where: { id: favorite.id, user_id: userId },
+        });
+
+        if (!existingFolder) {
+          throw new HttpException(
+            ErrorResponseUtil.badRequest('폴더를 찾을 수 없습니다.'),
+            HttpStatus.BAD_REQUEST,
+          );
+        }
+      }
+
+      // 2. 임시로 sort_order를 큰 값으로 설정
+      for (const favorite of favorites) {
+        await manager.update(
+          Favorite,
+          { id: favorite.id },
+          { sort_order: favorite.sort_order + 10000 },
+        );
+      }
+
+      // 3. 실제 sort_order로 설정
+      for (const favorite of favorites) {
+        await manager.update(
+          Favorite,
+          { id: favorite.id },
+          { sort_order: favorite.sort_order },
+        );
+      }
+
+      // 4. 폴더 이름 변경
+      for (const favorite of favorites) {
+        await manager.update(
+          Favorite,
+          { id: favorite.id },
+          { name: favorite.name },
+        );
+      }
+
+      // 5. 수정된 폴더 조회
+      return manager.find(Favorite, {
+        where: { user_id: userId },
+        order: { sort_order: 'ASC' },
+      });
+    });
   }
 }

--- a/src/modules/favorite/favorite-folder.service.ts
+++ b/src/modules/favorite/favorite-folder.service.ts
@@ -1,6 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { FavoriteFolderRepository } from './favorite-folder.repository';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
+import { FavoriteItemDto } from './dto';
 
 @Injectable()
 export class FavoriteFolderService {
@@ -104,6 +105,24 @@ export class FavoriteFolderService {
     return {
       success: true,
       message: 'Favorite Folder deleted successfully.',
+    };
+  }
+
+  async updateFavoriteFolder(favorites: FavoriteItemDto[], userId: string) {
+    const updatedFolder =
+      await this.favoriteRepository.updateFavoriteFolderWithTransation(
+        favorites,
+        userId,
+      );
+
+    return {
+      success: true,
+      message: 'Favorite Folder updated successfully.',
+      data: updatedFolder.map((folder) => ({
+        id: folder.id,
+        name: folder.name,
+        sort_order: folder.sort_order,
+      })),
     };
   }
 }


### PR DESCRIPTION
## 주요 변경사항
### 1. 주요기능
- `PUT` `/api/favorites` 엔드포인트 추가
- **배열 형태**로 여러 폴더를 한 번에 편집 가능
- **폴더명 변경** 및 **정렬 순서 변경** 가능

### 2. 구현 내용
- FavoriteFolderController: 폴더 편집 API 엔드포인트
- FavoriteFolderService: 편집 요청 처리 및 응답 형식 변환
- FavoriteFolderRepository: DataSource 트랜잭션 기반 데이터베이스 작업
- UpdateFavoriteFolderBodyDto: 편집 요청 데이터 검증
- UpdateFavoriteFolderResponseDto: 편집 응답 데이터 형식