### PR TITLE
Feat#38

### DIFF
--- a/src/database/entities/portfolio/asset-history.entity.ts
+++ b/src/database/entities/portfolio/asset-history.entity.ts
@@ -16,7 +16,9 @@ export class AssetHistory {
   @Column({ type: 'int' })
   user_asset_id: number;
 
-  @ManyToOne(() => UserAsset)
+  @ManyToOne(() => UserAsset, (userAsset) => userAsset.asset_histories, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'user_asset_id' })
   user_asset: UserAsset;
 

--- a/src/database/entities/portfolio/category.entity.ts
+++ b/src/database/entities/portfolio/category.entity.ts
@@ -4,8 +4,10 @@ import {
   Column,
   ManyToOne,
   JoinColumn,
+  OneToMany,
 } from 'typeorm';
 import { Portfolio } from './portfolio.entity';
+import { UserAsset } from './user-asset.entity';
 
 @Entity('category')
 export class Category {
@@ -15,9 +17,17 @@ export class Category {
   @Column({ type: 'int' })
   portfolio_id: number;
 
-  @ManyToOne(() => Portfolio)
+  @ManyToOne(() => Portfolio, (portfolio) => portfolio.categories, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'portfolio_id' })
   portfolio: Portfolio;
+
+  @OneToMany(() => UserAsset, (asset) => asset.category, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  assets: UserAsset[];
 
   @Column({ type: 'varchar', length: 100 })
   name: string;

--- a/src/database/entities/portfolio/portfolio.entity.ts
+++ b/src/database/entities/portfolio/portfolio.entity.ts
@@ -6,8 +6,10 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  OneToMany,
 } from 'typeorm';
 import { User } from '../user/user.entity';
+import { Category } from './category.entity';
 
 @Entity('portfolio')
 export class Portfolio {
@@ -20,6 +22,12 @@ export class Portfolio {
   @ManyToOne(() => User)
   @JoinColumn({ name: 'user_id' })
   user: User;
+
+  @OneToMany(() => Category, (category) => category.portfolio, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  categories: Category[];
 
   @Column({ type: 'varchar', length: 100 })
   name: string;

--- a/src/database/entities/portfolio/user-asset.entity.ts
+++ b/src/database/entities/portfolio/user-asset.entity.ts
@@ -6,11 +6,13 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  OneToMany,
 } from 'typeorm';
 import { Category } from './category.entity';
 import { Asset } from '../asset/asset.entity';
 import { Institution } from '../code/institution.entity';
 import { CurrencyCode } from '../code/currency-code.entity';
+import { AssetHistory } from './asset-history.entity';
 
 @Entity('user_asset')
 export class UserAsset {
@@ -20,7 +22,9 @@ export class UserAsset {
   @Column({ type: 'int' })
   category_id: number;
 
-  @ManyToOne(() => Category)
+  @ManyToOne(() => Category, (category) => category.assets, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'category_id' })
   category: Category;
 
@@ -30,6 +34,12 @@ export class UserAsset {
   @ManyToOne(() => Asset)
   @JoinColumn({ name: 'asset_id' })
   asset: Asset;
+
+  @OneToMany(() => AssetHistory, (history) => history.user_asset, {
+    cascade: true,
+    onDelete: 'CASCADE',
+  })
+  asset_histories: AssetHistory[];
 
   @Column({ type: 'int' })
   institution_id: number;

--- a/src/modules/portfolio/dto/requests/portfolio/delete-portfolio.dto.ts
+++ b/src/modules/portfolio/dto/requests/portfolio/delete-portfolio.dto.ts
@@ -1,9 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, Min } from 'class-validator';
+import { IsString } from 'class-validator';
 
 export class DeletePortfolioParamDto {
   @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  portfolio_id: number;
+  @IsString()
+  portfolio_id: string;
 }

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -116,14 +116,15 @@ export class PortfolioController {
   @ApiPortfolioParam()
   @ApiDeletePortfolioResponse()
   @ApiCommonErrorResponses()
+  @UseGuards(JwtAuthGuard)
   async deletePortfolio(
     @Param() deletePortfolioParamDto: DeletePortfolioParamDto,
+    @User() user: any,
   ): Promise<DeletePortfolioResponseDto> {
-    const mockData: DeletePortfolioResponseDto = {
-      success: true,
-      message: 'Portfolio deleted successfully.',
-    };
-    return mockData;
+    return await this.portfolioService.deletePortfolio(
+      Number(deletePortfolioParamDto.portfolio_id),
+      user.id,
+    );
   }
 
   @Put(':portfolio_id')

--- a/src/modules/portfolio/portfolio/portfolio.repository.ts
+++ b/src/modules/portfolio/portfolio/portfolio.repository.ts
@@ -62,4 +62,42 @@ export class PortfolioRepository {
       return createdPortfolio;
     });
   }
+
+  async executeDeletePortfolioTransaction(
+    portfolioId: number,
+    userId: string,
+  ): Promise<void> {
+    return this.dataSource.transaction(async (manager) => {
+      // 1. 포트폴리오 존재 및 소유자 여부 조회
+      const existingPortfolio = await manager.findOne(Portfolio, {
+        where: {
+          id: portfolioId,
+          user_id: userId,
+        },
+      });
+
+      if (!existingPortfolio) {
+        throw new Error('Portfolio not found');
+      }
+
+      // 2. 삭제 포트폴리오 정렬 번호 조회
+      const deletedSortOrder = existingPortfolio.sort_order;
+
+      // 3. 포트폴리오 삭제
+      await manager.delete(Portfolio, { id: portfolioId });
+
+      // 4. 정렬 순서 업데이트
+      await manager
+        .createQueryBuilder()
+        .update(Portfolio)
+        .set({
+          sort_order: () => 'sort_order - 1',
+        })
+        .where('user_id = :userId AND sort_order > :deletedSortOrder', {
+          userId,
+          deletedSortOrder,
+        })
+        .execute();
+    });
+  }
 }

--- a/src/modules/portfolio/portfolio/portfolio.service.ts
+++ b/src/modules/portfolio/portfolio/portfolio.service.ts
@@ -1,6 +1,7 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { PortfolioRepository } from './portfolio.repository';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
+import { DeletePortfolioParamDto } from '../dto';
 
 @Injectable()
 export class PortfolioService {
@@ -73,6 +74,31 @@ export class PortfolioService {
         );
       }
 
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError(error.message),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+
+  async deletePortfolio(portfolioId: number, userId: string) {
+    try {
+      await this.portfolioRepository.executeDeletePortfolioTransaction(
+        portfolioId,
+        userId,
+      );
+
+      return {
+        success: true,
+        message: 'Portfolio deleted successfully.',
+      };
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
       throw new HttpException(
         ErrorResponseUtil.internalServerError(error.message),
         HttpStatus.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
# 🚀 포트폴리오 삭제 기능 및 CASCADE 설정 구현

## ✨ 주요 변경사항

### 1. 주요 기능

- **DELETE** `/api/portfolios/{portfolio_id}` 엔드포인트 추가
- 포트폴리오 삭제 시 정렬 순서 자동 재정렬
- CASCADE 설정으로 관련 데이터 자동 삭제

### 2. 구현 내용

- **Controller**: 포트폴리오 삭제 API 엔드포인트 구현
- **Service**: 비즈니스 로직 및 에러 핸들링
- **Repository**: 트랜잭션 기반 삭제 및 정렬 순서 업데이트
- **Entity**: Portfolio, Category, UserAsset, AssetHistory 간 CASCADE 관계 설정

## ✅ 체크리스트

- [x] API 엔드포인트 구현
- [x] 비즈니스 로직 구현
- [x] 데이터베이스 작업
- [x] 에러 핸들링
- [x] Swagger 문서화
- [x] CASCADE 설정 완료

## 🔒 보안

- JWT 토큰을 통한 사용자 인증
- 포트폴리오 소유권 검증으로 권한 관리
- 트랜잭션을 통한 데이터 무결성 보장

---

**변경된 파일들:**
- `portfolio.controller.ts`: DELETE 엔드포인트 추가
- `portfolio.service.ts`: 삭제 비즈니스 로직 구현
- `portfolio.repository.ts`: 트랜잭션 기반 삭제 로직
- `portfolio.entity.ts`: Category와의 CASCADE 관계 설정
- `category.entity.ts`: UserAsset과의 CASCADE 관계 설정
- `user-asset.entity.ts`: AssetHistory와의 CASCADE 관계 설정
- `asset-history.entity.ts`: UserAsset과의 CASCADE 관계 설정