### PR TITLE
Feat#42 포트폴리오 API 모듈 분리 및 카테고리 생성 기능 구현

### DIFF
--- a/src/database/entities/portfolio/category.entity.ts
+++ b/src/database/entities/portfolio/category.entity.ts
@@ -5,6 +5,8 @@ import {
   ManyToOne,
   JoinColumn,
   OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
 } from 'typeorm';
 import { Portfolio } from './portfolio.entity';
 import { UserAsset } from './user-asset.entity';
@@ -34,4 +36,10 @@ export class Category {
 
   @Column({ type: 'int' })
   sort_order: number;
+
+  @CreateDateColumn({ name: 'created_at' })
+  created_at: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updated_at: Date;
 }

--- a/src/modules/portfolio/category/category.controller.ts
+++ b/src/modules/portfolio/category/category.controller.ts
@@ -1,7 +1,150 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { CategoryService } from './category.service';
 
-@Controller('category')
+import {
+  ApiCommonErrorResponses,
+  ApiCommonErrorResponsesWithNotFound,
+  ApiCategoryParams,
+  ApiGetCategoriesSummaryResponse,
+  ApiCreateCategory,
+  ApiDeleteCategoryResponse,
+  ApiUpdateCategory,
+} from 'src/common/swagger';
+
+import {
+  CreateCategoryParamDto,
+  CreateCategoryRequestDto,
+  CreateCategoryResponseDto,
+  DeleteCategoryParamDto,
+  DeleteCategoryResponseDto,
+  GetCategoriesSummaryParamDto,
+  GetCategoriesSummaryQueryDto,
+  GetCategoriesSummaryResponseDto,
+  UpdateCategoryParamDto,
+  UpdateCategoryRequestDto,
+  UpdateCategoryResponseDto,
+} from '../dto';
+import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/modules/auth/guards';
+import { User } from 'src/modules/auth/decorators/user.decorator';
+
+@Controller('portfolios/:portfolio_id/categories')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
+
+  @Get(':category_id')
+  @ApiOperation({ summary: '카테고리별 평가자산 조회' })
+  @ApiCategoryParams()
+  @ApiQuery({
+    name: 'sortBy',
+    description: '정렬 기준',
+    example: 'name',
+    type: GetCategoriesSummaryQueryDto,
+  })
+  @ApiQuery({
+    name: 'order',
+    description: '정렬 순서',
+    example: 'asc',
+    type: GetCategoriesSummaryQueryDto,
+  })
+  @ApiGetCategoriesSummaryResponse()
+  @ApiCommonErrorResponsesWithNotFound()
+  async getCategorySummary(
+    @Param() getCategoriesSummaryParamDto: GetCategoriesSummaryParamDto,
+    @Query() getCategoriesSummaryQueryDto: GetCategoriesSummaryQueryDto,
+  ): Promise<GetCategoriesSummaryResponseDto> {
+    const mockData: GetCategoriesSummaryResponseDto = {
+      success: true,
+      message: 'Portfolio assets retrieved successfully.',
+      data: {
+        portfolio_id: 1,
+        portfolio_name: '승수의 장기투자',
+        created_at: '2024-03-02T00:00:00Z',
+        updated_at: '2025-07-02T00:00:00Z',
+        sorted_by: 'price',
+        categories: [{ category_id: 21, category_name: '예수금' }],
+        assets: [
+          {
+            asset_id: 23,
+            category_id: 22,
+            category_name: '국내주식',
+            asset_name: '삼성전자',
+            current_price: 60500,
+            avg_price: 60000,
+            quantity: 20,
+            purchase_amount: 1200000,
+            eval_amount: 1210000,
+            profit_amount: 10000,
+            profit_rate: 0.1,
+          },
+        ],
+      },
+    };
+    return mockData;
+  }
+
+  @Post()
+  @ApiOperation({ summary: '카테고리 생성' })
+  @ApiCategoryParams()
+  @ApiCreateCategory()
+  @ApiCommonErrorResponses()
+  @UseGuards(JwtAuthGuard)
+  async createCategory(
+    @Param() createCategoryParamDto: CreateCategoryParamDto,
+    @Body() createCategoryRequestDto: CreateCategoryRequestDto,
+    @User() user: any,
+  ): Promise<CreateCategoryResponseDto> {
+    return await this.categoryService.createCategory(
+      user.id,
+      Number(createCategoryParamDto.portfolio_id),
+      createCategoryRequestDto.name,
+    );
+  }
+
+  @Delete(':category_id')
+  @ApiOperation({ summary: '카테고리 삭제' })
+  @ApiCategoryParams()
+  @ApiDeleteCategoryResponse()
+  @ApiCommonErrorResponses()
+  async deleteCategory(
+    @Param() deleteCategoryParamDto: DeleteCategoryParamDto,
+  ): Promise<DeleteCategoryResponseDto> {
+    const mockData: DeleteCategoryResponseDto = {
+      success: true,
+      message: 'Category deleted successfully.',
+    };
+    return mockData;
+  }
+
+  @Put(':category_id')
+  @ApiOperation({ summary: '카테고리 수정' })
+  @ApiCategoryParams()
+  @ApiUpdateCategory()
+  @ApiCommonErrorResponsesWithNotFound()
+  async updateCategory(
+    @Param() updateCategoryParamDto: UpdateCategoryParamDto,
+    @Body() updateCategoryRequestDto: UpdateCategoryRequestDto,
+  ): Promise<UpdateCategoryResponseDto> {
+    const mockData: UpdateCategoryResponseDto = {
+      success: true,
+      message: 'Category updated successfully.',
+      data: {
+        category_id: 23,
+        portfolio_id: 1,
+        name: '수정된 카테고리명',
+        updated_at: '2025-07-03T12:15:45.000Z',
+      },
+    };
+    return mockData;
+  }
 }

--- a/src/modules/portfolio/category/category.repository.ts
+++ b/src/modules/portfolio/category/category.repository.ts
@@ -1,6 +1,56 @@
 import { Injectable } from '@nestjs/common';
+import { Category } from 'src/database/entities/portfolio/category.entity';
+import { Portfolio } from 'src/database/entities/portfolio/portfolio.entity';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class CategoryRepository {
-  constructor() {}
+  constructor(private dataSource: DataSource) {}
+
+  async executeCreateCategoryTransaction(
+    userId: string,
+    portfolioId: number,
+    name: string,
+  ) {
+    return this.dataSource.transaction(async (manager) => {
+      // 1. 포트폴리오 존재 여부 및 소유권 검증
+      const existingPortfolio = await manager.findOne(Portfolio, {
+        where: { id: portfolioId, user_id: userId },
+      });
+
+      if (!existingPortfolio) {
+        throw new Error('Portfolio not found');
+      }
+      // 2. 카테고리 중복 조회
+      const existingCategory = await manager.findOne(Category, {
+        where: { name, portfolio_id: portfolioId },
+      });
+
+      if (existingCategory) {
+        throw new Error('Category already exists');
+      }
+
+      // 3. 정렬 순서 최대값 조회
+      const maxSortOrder = await manager.findOne(Category, {
+        where: { portfolio_id: portfolioId },
+        order: { sort_order: 'DESC' },
+      });
+
+      const newSortOrder = maxSortOrder ? maxSortOrder.sort_order + 1 : 1;
+
+      // 4. 카테고리 생성
+      const newCategory = await manager.save(Category, {
+        name,
+        portfolio_id: portfolioId,
+        sort_order: newSortOrder,
+      });
+
+      // 5. 카테고리 생성 결과 반환
+      const createdCategory = await manager.findOne(Category, {
+        where: { id: newCategory.id },
+      });
+
+      return createdCategory;
+    });
+  }
 }

--- a/src/modules/portfolio/category/category.service.ts
+++ b/src/modules/portfolio/category/category.service.ts
@@ -1,4 +1,57 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CategoryRepository } from './category.repository';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 @Injectable()
-export class CategoryService {}
+export class CategoryService {
+  constructor(private readonly categoryRepository: CategoryRepository) {}
+
+  async createCategory(userId: string, portfolioId: number, name: string) {
+    try {
+      const category =
+        await this.categoryRepository.executeCreateCategoryTransaction(
+          userId,
+          portfolioId,
+          name,
+        );
+
+      if (!category) {
+        throw new HttpException(
+          ErrorResponseUtil.internalServerError('Failed to create category'),
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Category created successfully.',
+        data: {
+          category_id: category.id,
+          portfolio_id: category.portfolio_id,
+          category_name: category.name,
+          created_at: category.created_at.toISOString().split('T')[0],
+          updated_at: category.updated_at.toISOString().split('T')[0],
+        },
+      };
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category already exists') {
+        throw new HttpException(
+          ErrorResponseUtil.badRequest('Category already exists'),
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError('Failed to create category'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
+}

--- a/src/modules/portfolio/dto/requests/category/create-category.dto.ts
+++ b/src/modules/portfolio/dto/requests/category/create-category.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsString, Length, Min } from 'class-validator';
+import { IsString, Length } from 'class-validator';
 
 export class CreateCategoryRequestDto {
   @ApiProperty({ description: '카테고리 이름', example: '카테고리 1' })
@@ -10,7 +10,6 @@ export class CreateCategoryRequestDto {
 
 export class CreateCategoryParamDto {
   @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  portfolio_id: number;
+  @IsString()
+  portfolio_id: string;
 }

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -28,10 +28,6 @@ import {
   ApiDeletePortfolioResponse,
   ApiUpdatePortfolio,
   ApiGetPortfolioSummaryResponse,
-  ApiGetCategoriesSummaryResponse,
-  ApiCreateCategory,
-  ApiDeleteCategoryResponse,
-  ApiUpdateCategory,
   ApiCreateAssetHistory,
   ApiDeleteAssetResponse,
   ApiGetAssetHistoryResponse,
@@ -43,43 +39,32 @@ import {
   CreateAssetHistoryParamDto,
   CreateAssetHistoryRequestDto,
   CreateAssetHistoryResponseDto,
-  CreateCategoryParamDto,
-  CreateCategoryRequestDto,
-  CreateCategoryResponseDto,
   CreatePortfolioRequestDto,
   CreatePortfolioResponseDto,
   DeleteAssetHistoryParamsDto,
   DeleteAssetHistoryResponseDto,
   DeleteAssetParamDto,
   DeleteAssetResponseDto,
-  DeleteCategoryParamDto,
-  DeleteCategoryResponseDto,
   DeletePortfolioParamDto,
   DeletePortfolioResponseDto,
   GetAllPortfolioResponseDto,
   GetAssetHistoryParamDto,
   GetAssetHistoryQueryDto,
   GetAssetHistoryResponseDto,
-  GetCategoriesSummaryParamDto,
-  GetCategoriesSummaryQueryDto,
-  GetCategoriesSummaryResponseDto,
   GetPortfolioSummaryParamDto,
   GetPortfolioSummaryResponseDto,
   UpdateAssetHistoryParamsDto,
   UpdateAssetHistoryRequestDto,
   UpdateAssetHistoryResponseDto,
-  UpdateCategoryParamDto,
-  UpdateCategoryRequestDto,
-  UpdateCategoryResponseDto,
   UpdatePortfolioRequestDto,
   UpdatePortfolioResponseDto,
 } from '../dto';
 import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
 
-@ApiTags('portfolio')
+@ApiTags('portfolios')
 @ApiBearerAuth()
-@Controller('portfolio')
+@Controller('portfolios')
 export class PortfolioController {
   constructor(private readonly portfolioService: PortfolioService) {}
 
@@ -155,117 +140,6 @@ export class PortfolioController {
       Number(getPortfolioSummaryParamDto.portfolio_id),
       user.id,
     );
-  }
-
-  @Get(':portfolio_id/categories/:category_id')
-  @ApiOperation({ summary: '카테고리별 평가자산 조회' })
-  @ApiCategoryParams()
-  @ApiQuery({
-    name: 'sortBy',
-    description: '정렬 기준',
-    example: 'name',
-    type: GetCategoriesSummaryQueryDto,
-  })
-  @ApiQuery({
-    name: 'order',
-    description: '정렬 순서',
-    example: 'asc',
-    type: GetCategoriesSummaryQueryDto,
-  })
-  @ApiGetCategoriesSummaryResponse()
-  @ApiCommonErrorResponsesWithNotFound()
-  async getCategorySummary(
-    @Param() getCategoriesSummaryParamDto: GetCategoriesSummaryParamDto,
-    @Query() getCategoriesSummaryQueryDto: GetCategoriesSummaryQueryDto,
-  ): Promise<GetCategoriesSummaryResponseDto> {
-    const mockData: GetCategoriesSummaryResponseDto = {
-      success: true,
-      message: 'Portfolio assets retrieved successfully.',
-      data: {
-        portfolio_id: 1,
-        portfolio_name: '승수의 장기투자',
-        created_at: '2024-03-02T00:00:00Z',
-        updated_at: '2025-07-02T00:00:00Z',
-        sorted_by: 'price',
-        categories: [{ category_id: 21, category_name: '예수금' }],
-        assets: [
-          {
-            asset_id: 23,
-            category_id: 22,
-            category_name: '국내주식',
-            asset_name: '삼성전자',
-            current_price: 60500,
-            avg_price: 60000,
-            quantity: 20,
-            purchase_amount: 1200000,
-            eval_amount: 1210000,
-            profit_amount: 10000,
-            profit_rate: 0.1,
-          },
-        ],
-      },
-    };
-    return mockData;
-  }
-
-  @Post(':portfolio_id/categories/:category_id')
-  @ApiOperation({ summary: '카테고리 생성' })
-  @ApiCategoryParams()
-  @ApiCreateCategory()
-  @ApiCommonErrorResponses()
-  async createCategory(
-    @Param() createCategoryParamDto: CreateCategoryParamDto,
-    @Body() createCategoryRequestDto: CreateCategoryRequestDto,
-  ): Promise<CreateCategoryResponseDto> {
-    const mockData: CreateCategoryResponseDto = {
-      success: true,
-      message: 'Category created successfully.',
-      data: {
-        category_id: 21,
-        portfolio_id: 1,
-        category_name: '국내주식',
-        created_at: '2025-07-02T10:30:00Z',
-        updated_at: '2025-07-02T10:30:00Z',
-      },
-    };
-    return mockData;
-  }
-
-  @Delete(':portfolio_id/categories/:category_id')
-  @ApiOperation({ summary: '카테고리 삭제' })
-  @ApiCategoryParams()
-  @ApiDeleteCategoryResponse()
-  @ApiCommonErrorResponses()
-  async deleteCategory(
-    @Param() deleteCategoryParamDto: DeleteCategoryParamDto,
-  ): Promise<DeleteCategoryResponseDto> {
-    const mockData: DeleteCategoryResponseDto = {
-      success: true,
-      message: 'Category deleted successfully.',
-    };
-    return mockData;
-  }
-
-  @Put(':portfolio_id/categories/:category_id')
-  @ApiOperation({ summary: '카테고리 수정' })
-  @ApiCategoryParams()
-  @ApiUpdateCategory()
-  @ApiCommonErrorResponsesWithNotFound()
-  async updateCategory(
-    @Param() updateCategoryParamDto: UpdateCategoryParamDto,
-    @Body() updateCategoryRequestDto: UpdateCategoryRequestDto,
-  ): Promise<UpdateCategoryResponseDto> {
-    const mockData: UpdateCategoryResponseDto = {
-      success: true,
-      message: 'Category updated successfully.',
-      data: {
-        category_id: 23,
-        portfolio_id: 1,
-        name: '수정된 카테고리명',
-        updated_at: '2025-07-03T12:15:45.000Z',
-      },
-    };
-    return mockData;
   }
 
   @Post(':portfolio_id/categories/:category_id/assets')


### PR DESCRIPTION
### 주요 변경사항
- **API 모듈 분리**: portfolio, category, asset, asset-history 모듈로 구조화
- **RESTful 라우트 구조**: 복수형 URL로 일관성 확보 (`/portfolios/:id/categories`)
- **카테고리 생성 기능**: 포트폴리오별 카테고리 생성 API 구현
- **트랜잭션 처리**: 안전한 카테고리 생성 및 검증 로직

### 기술적 개선
- 계층적 URL 구조로 리소스 관계 명확화
- 모듈별 책임 분리로 코드 가독성 향상
- 표준화된 에러 응답 형식 적용
- 포트폴리오 소유권 및 중복 카테고리 검증

### 테스트
- `POST /api/portfolios/2/categories` 엔드포인트 정상 작동 확인