### PR TITLE
Feat#44 카테고리 수정 기능 구현 완료

### DIFF
--- a/src/modules/portfolio/category/category.controller.ts
+++ b/src/modules/portfolio/category/category.controller.ts
@@ -133,20 +133,17 @@ export class CategoryController {
   @ApiCategoryParams()
   @ApiUpdateCategory()
   @ApiCommonErrorResponsesWithNotFound()
+  @UseGuards(JwtAuthGuard)
   async updateCategory(
     @Param() updateCategoryParamDto: UpdateCategoryParamDto,
     @Body() updateCategoryRequestDto: UpdateCategoryRequestDto,
+    @User() user: any,
   ): Promise<UpdateCategoryResponseDto> {
-    const mockData: UpdateCategoryResponseDto = {
-      success: true,
-      message: 'Category updated successfully.',
-      data: {
-        category_id: 23,
-        portfolio_id: 1,
-        name: '수정된 카테고리명',
-        updated_at: '2025-07-03T12:15:45.000Z',
-      },
-    };
-    return mockData;
+    return await this.categoryService.updateCategory(
+      user.id,
+      Number(updateCategoryParamDto.portfolio_id),
+      Number(updateCategoryParamDto.category_id),
+      updateCategoryRequestDto.name,
+    );
   }
 }

--- a/src/modules/portfolio/category/category.repository.ts
+++ b/src/modules/portfolio/category/category.repository.ts
@@ -99,4 +99,58 @@ export class CategoryRepository {
         .execute();
     });
   }
+
+  async executeUpdateCategoryTransaction(
+    userId: string,
+    portfolioId: number,
+    categoryId: number,
+    name: string,
+  ) {
+    return this.dataSource.transaction(async (manager) => {
+      // 1-1. 포트폴리오 존재 여부 및 소유권 검증
+      const existingPortfolio = await manager.findOne(Portfolio, {
+        where: { id: portfolioId, user_id: userId },
+      });
+
+      if (!existingPortfolio) {
+        throw new Error('Portfolio not found');
+      }
+
+      // 1-2. 카테고리 존재 여부 및 소유권 검증
+      const existingCategory = await manager.findOne(Category, {
+        where: { id: categoryId, portfolio_id: portfolioId },
+      });
+
+      if (!existingCategory) {
+        throw new Error('Category not found');
+      }
+
+      // 2. 카테고리 이름 중복 검증
+      const existingCategoryWithSameName = await manager.findOne(Category, {
+        where: { name, portfolio_id: portfolioId },
+      });
+
+      if (existingCategoryWithSameName) {
+        throw new Error('Category name already exists');
+      }
+
+      // 3. 카테고리 이름 업데이트
+      await manager
+        .createQueryBuilder()
+        .update(Category)
+        .set({ name })
+        .where('id = :id AND portfolio_id = :portfolioId', {
+          id: categoryId,
+          portfolioId,
+        })
+        .execute();
+
+      // 4. 업데이트된 카테고리 조회
+      const updatedCategory = await manager.findOne(Category, {
+        where: { id: categoryId, portfolio_id: portfolioId },
+      });
+
+      return updatedCategory;
+    });
+  }
 }

--- a/src/modules/portfolio/category/category.service.ts
+++ b/src/modules/portfolio/category/category.service.ts
@@ -99,4 +99,66 @@ export class CategoryService {
       );
     }
   }
+
+  async updateCategory(
+    userId: string,
+    portfolioId: number,
+    categoryId: number,
+    name: string,
+  ) {
+    try {
+      const updatedCategory =
+        await this.categoryRepository.executeUpdateCategoryTransaction(
+          userId,
+          portfolioId,
+          categoryId,
+          name,
+        );
+
+      if (!updatedCategory) {
+        throw new HttpException(
+          ErrorResponseUtil.internalServerError('Failed to update category'),
+          HttpStatus.INTERNAL_SERVER_ERROR,
+        );
+      }
+
+      return {
+        success: true,
+        message: 'Category updated successfully.',
+        data: {
+          category_id: updatedCategory.id,
+          portfolio_id: updatedCategory.portfolio_id,
+          name: updatedCategory.name,
+          created_at: updatedCategory.created_at.toISOString().split('T')[0],
+          updated_at: updatedCategory.updated_at.toISOString().split('T')[0],
+        },
+      };
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Category not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category name already exists') {
+        throw new HttpException(
+          ErrorResponseUtil.badRequest('Category name already exists'),
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+    }
+
+    throw new HttpException(
+      ErrorResponseUtil.internalServerError('Failed to update category'),
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+  }
 }

--- a/src/modules/portfolio/dto/requests/category/update-category.dto.ts
+++ b/src/modules/portfolio/dto/requests/category/update-category.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, IsString, Length, Min } from 'class-validator';
+import { IsString, Length } from 'class-validator';
 
 export class UpdateCategoryRequestDto {
   @ApiProperty({ description: '카테고리 이름', example: '카테고리 1' })
@@ -10,12 +10,10 @@ export class UpdateCategoryRequestDto {
 
 export class UpdateCategoryParamDto {
   @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  portfolio_id: number;
+  @IsString()
+  portfolio_id: string;
 
   @ApiProperty({ description: '카테고리 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  category_id: number;
+  @IsString()
+  category_id: string;
 }

--- a/src/modules/portfolio/dto/responses/category/update-category.dto.ts
+++ b/src/modules/portfolio/dto/responses/category/update-category.dto.ts
@@ -10,6 +10,9 @@ export class UpdateCategoryItem {
   @ApiProperty({ description: '카테고리 이름', example: '카테고리 1' })
   name: string;
 
+  @ApiProperty({ description: '생성일', example: '2021-01-01' })
+  created_at: string;
+
   @ApiProperty({ description: '수정일', example: '2021-01-01' })
   updated_at: string;
 }

--- a/src/modules/portfolio/portfolio/portfolio.repository.ts
+++ b/src/modules/portfolio/portfolio/portfolio.repository.ts
@@ -190,6 +190,7 @@ export class PortfolioRepository {
       const categories = await manager.find(Category, {
         where: { portfolio_id: portfolioId },
         select: ['id', 'name', 'sort_order'],
+        order: { sort_order: 'ASC' },
       });
 
       // 3-1. 카테고리가 없는 경우(포트폴리오 생성하고 바로 조회할 경우) 반환


### PR DESCRIPTION
### 주요 변경사항
- **카테고리 수정 API**: PUT `/portfolios/:id/categories/:id` 엔드포인트 구현
- **데이터 검증**: 포트폴리오 소유권, 카테고리 존재 여부, 이름 중복 검증
- **트랜잭션 처리**: 안전한 카테고리 수정 및 에러 처리
- **DTO 구조**: 카테고리 수정 요청/응답 데이터 구조 정의

### 기술적 특징
- TypeORM 트랜잭션 기반 안전한 데이터 수정
- 표준화된 에러 응답 형식 적용
- Swagger API 문서화 지원

### 테스트
- 카테고리 수정 API 정상 작동 확인
- 중복 이름 검증 및 에러 처리 검증 완료