### PR TITLE
Feat#46 자산 삭제 기능 구현

### DIFF
--- a/src/database/entities/portfolio/asset-history.entity.ts
+++ b/src/database/entities/portfolio/asset-history.entity.ts
@@ -51,7 +51,4 @@ export class AssetHistory {
 
   @UpdateDateColumn({ name: 'updated_at' })
   updated_at: Date;
-
-  @Column({ type: 'boolean', default: false })
-  deleted: boolean;
 }

--- a/src/database/entities/portfolio/user-asset.entity.ts
+++ b/src/database/entities/portfolio/user-asset.entity.ts
@@ -78,7 +78,4 @@ export class UserAsset {
 
   @UpdateDateColumn({ name: 'updated_at' })
   updated_at: Date;
-
-  @Column({ type: 'boolean', default: false })
-  deleted: boolean;
 }

--- a/src/modules/portfolio/asset-history/asset-history.repository.ts
+++ b/src/modules/portfolio/asset-history/asset-history.repository.ts
@@ -1,7 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { Asset } from 'src/database/entities/asset/asset.entity';
-import { Category } from 'src/database/entities/portfolio/category.entity';
-import { Portfolio } from 'src/database/entities/portfolio/portfolio.entity';
 import { UserAsset } from 'src/database/entities/portfolio/user-asset.entity';
 import { DataSource } from 'typeorm';
 import { CreateAssetHistoryRequestDto } from '../dto';
@@ -11,213 +8,27 @@ import { AssetHistory } from 'src/database/entities/portfolio/asset-history.enti
 export class AssetHistoryRepository {
   constructor(private dataSource: DataSource) {}
 
-  async validatePortfolioAndFindUserAsset(
-    portfolioId: number,
-    categoryId: number,
-    assetId: number,
-    institutionId: number,
-    currencyCodeId: number,
-    userId: string,
-  ) {
-    console.log('🔍 === validatePortfolioAndFindUserAsset START ===');
-    console.log('📊 Input Parameters:');
-    console.log('  portfolioId:', portfolioId, '(', typeof portfolioId, ')');
-    console.log('  categoryId:', categoryId, '(', typeof categoryId, ')');
-    console.log('  assetId:', assetId, '(', typeof assetId, ')');
-    console.log(
-      '  institutionId:',
-      institutionId,
-      '(',
-      typeof institutionId,
-      ')',
-    );
-    console.log(
-      '  currencyCodeId:',
-      currencyCodeId,
-      '(',
-      typeof currencyCodeId,
-      ')',
-    );
-    console.log('  userId:', userId, '(', typeof userId, ')');
-
-    return this.dataSource.transaction(async (manager) => {
-      // 1. 포트폴리오 소유권 검증
-      console.log('🔍 1. Checking Portfolio ownership...');
-      const portfolio = await manager.findOne(Portfolio, {
-        where: { id: portfolioId, user_id: userId },
-      });
-
-      console.log('�� Found Portfolio:', portfolio);
-
-      if (!portfolio) {
-        console.log('❌ Portfolio not found!');
-        throw new Error('Portfolio not found');
-      }
-
-      // 2. 카테고리 소유권 검증
-      console.log('🔍 2. Checking Category ownership...');
-      const category = await manager.findOne(Category, {
-        where: { id: categoryId, portfolio_id: portfolioId },
-      });
-
-      console.log('📊 Found Category:', category);
-
-      if (!category) {
-        console.log('❌ Category not found!');
-        throw new Error('Category not found');
-      }
-
-      // 3. 자산 존재 여부
-      console.log('🔍 3. Checking Asset existence...');
-      console.log('🔍 Searching Asset with ID:', assetId);
-
-      // Asset 테이블의 전체 개수 확인
-      const assetCount = await manager.count(Asset);
-      console.log('📊 Total Asset count:', assetCount);
-
-      // Asset ID 범위 확인 - 간단한 버전
-      if (assetCount > 0) {
-        const allAssets = await manager.find(Asset, {
-          select: ['id'],
-          order: { id: 'ASC' },
-        });
-
-        if (allAssets.length > 0) {
-          const minAssetId = allAssets[0].id;
-          const maxAssetId = allAssets[allAssets.length - 1].id;
-          console.log('📊 Asset ID range:', minAssetId, '~', maxAssetId);
-
-          // Asset ID가 범위 내에 있는지 확인
-          if (assetId < minAssetId || assetId > maxAssetId) {
-            console.log('❌ Asset ID out of range!');
-            console.log('   Requested ID:', assetId);
-            console.log('   Available range:', minAssetId, '~', maxAssetId);
-          }
-        }
-      } else {
-        console.log('�� No assets found in database');
-      }
-
-      const asset = await manager.findOne(Asset, {
-        where: { id: assetId },
-      });
-
-      console.log('📊 Found Asset:', asset);
-
-      if (!asset) {
-        console.log('❌ Asset not found!');
-        console.log('   Requested Asset ID:', assetId);
-
-        if (assetCount > 0) {
-          console.log('   Available Asset IDs (first 10):');
-          const sampleAssets = await manager.find(Asset, {
-            select: ['id'],
-            take: 10,
-            order: { id: 'ASC' },
-          });
-          console.log(
-            '   Sample Asset IDs:',
-            sampleAssets.map((a) => a.id),
-          );
-        }
-
-        throw new Error('Asset not found');
-      }
-
-      // 4. UserAsset 존재 여부
-      console.log('🔍 4. Checking UserAsset existence...');
-      console.log('🔍 Searching UserAsset with criteria:');
-      console.log('   asset_id:', assetId);
-      console.log('   category_id:', categoryId);
-      console.log('   institution_id:', institutionId);
-      console.log('   currency_code_id:', currencyCodeId);
-
-      const userAsset = await manager.findOne(UserAsset, {
-        where: {
-          asset_id: assetId,
-          category_id: categoryId,
-          institution_id: institutionId,
-          currency_code_id: currencyCodeId,
-        },
-      });
-
-      console.log('�� Found UserAsset:', userAsset);
-
-      // UserAsset이 없는 경우, 해당 카테고리에 다른 UserAsset이 있는지 확인
-      if (!userAsset) {
-        console.log(
-          '🔍 4-1. No UserAsset found, checking other UserAssets in same category...',
-        );
-        const otherUserAssets = await manager.find(UserAsset, {
-          where: { category_id: categoryId },
-          select: ['id', 'asset_id', 'institution_id', 'currency_code_id'],
-        });
-        console.log('📊 Other UserAssets in category:', otherUserAssets);
-      }
-
-      console.log('🔍 === validatePortfolioAndFindUserAsset END ===');
-
-      return {
-        portfolio,
-        category,
-        asset,
-        userAsset,
-      };
-    });
-  }
-
   async createAssetHistory(
     createAssetHistoryRequestDto: CreateAssetHistoryRequestDto,
     userAssetId: number,
     manager?: any, // 기존 트랜잭션의 manager를 받을 수 있도록
   ) {
-    console.log('🔍 === createAssetHistory START ===');
-    console.log('📊 Input Parameters:');
-    console.log('  userAssetId:', userAssetId, '(', typeof userAssetId, ')');
-    console.log('  DTO:', createAssetHistoryRequestDto);
-
-    const {
-      institution_id,
-      currency_code_id,
-      asset_history_type_id,
-      price,
-      quantity,
-      memo,
-      recorded_at,
-    } = createAssetHistoryRequestDto;
+    const { asset_history_type_id, price, quantity, memo, recorded_at } =
+      createAssetHistoryRequestDto;
 
     // 트랜잭션 실행 함수
     const executeInTransaction = async (transactionManager: any) => {
       // 1. UserAsset 정보 조회 (institution_id, currency_code_id 등)
-      console.log('🔍 1. Fetching UserAsset information...');
       const userAsset = await transactionManager.findOne(UserAsset, {
         where: { id: userAssetId },
         relations: ['category', 'asset'], // 관계 데이터도 함께 조회
       });
 
-      console.log('�� Found UserAsset:', userAsset);
-
       if (!userAsset) {
-        console.log('❌ UserAsset not found!');
         throw new Error('UserAsset not found');
       }
 
       // 2. AssetHistory 생성
-      console.log('🔍 2. Creating AssetHistory...');
-      console.log('�� AssetHistory data:');
-      console.log('   user_asset_id:', userAssetId);
-      console.log('   recorded_at:', recorded_at, '→', new Date(recorded_at));
-      console.log('   asset_history_type_id:', asset_history_type_id);
-      console.log('   price:', price, '→', price.toString());
-      console.log('   quantity:', quantity, '→', quantity.toString());
-      console.log(
-        '   total_amount:',
-        price * quantity,
-        '→',
-        (price * quantity).toString(),
-      );
-      console.log('   memo:', memo);
-
       const assetHistory = await transactionManager.create(AssetHistory, {
         user_asset_id: userAssetId,
         recorded_at: new Date(recorded_at),
@@ -229,37 +40,19 @@ export class AssetHistoryRepository {
         deleted: false,
       });
 
-      console.log('📊 Created AssetHistory entity:', assetHistory);
-
       await transactionManager.save(assetHistory);
-      console.log('✅ AssetHistory saved to database');
 
       // 3. 매수/매도인 경우 수량 업데이트
       if (asset_history_type_id === 1 || asset_history_type_id === 2) {
-        console.log(
-          '🔍 3. Updating UserAsset quantity (buy/sell transaction)...',
-        );
-        console.log(
-          '   Transaction type:',
-          asset_history_type_id === 1 ? 'BUY' : 'SELL',
-        );
-        console.log('   Quantity to add/subtract:', quantity);
-
         await this.updateUserAssetQuantity(
           userAssetId,
           asset_history_type_id,
           quantity,
           transactionManager, // 같은 트랜잭션의 manager 전달
         );
-        console.log('✅ UserAsset quantity updated');
-      } else {
-        console.log(
-          '🔍 3. Skipping quantity update (not buy/sell transaction)',
-        );
       }
 
       // 4. 필요한 모든 데이터를 포함하여 반환
-      console.log('🔍 4. Preparing response data...');
       const responseData = {
         asset_id: userAsset.asset_id,
         category_id: userAsset.category_id,
@@ -274,18 +67,13 @@ export class AssetHistoryRepository {
         updated_at: assetHistory.updated_at,
       };
 
-      console.log('📊 Response data prepared:', responseData);
-      console.log('🔍 === createAssetHistory END ===');
-
       return responseData;
     };
 
     // manager가 있으면 기존 트랜잭션 사용, 없으면 새 트랜잭션 생성
     if (manager) {
-      console.log('🔍 Using existing transaction manager');
       return await executeInTransaction(manager);
     } else {
-      console.log('🔍 Creating new transaction');
       return this.dataSource.transaction(executeInTransaction);
     }
   }
@@ -297,13 +85,6 @@ export class AssetHistoryRepository {
     createAssetHistoryRequestDto: CreateAssetHistoryRequestDto,
     userId: string,
   ) {
-    console.log('🔍 === createUserAssetAndAssetHistory START ===');
-    console.log('📊 Input Parameters:');
-    console.log('  categoryId:', categoryId, '(', typeof categoryId, ')');
-    console.log('  assetId:', assetId, '(', typeof assetId, ')');
-    console.log('  userId:', userId, '(', typeof userId, ')');
-    console.log('  DTO:', createAssetHistoryRequestDto);
-
     const {
       institution_id,
       currency_code_id,
@@ -316,15 +97,6 @@ export class AssetHistoryRepository {
 
     return this.dataSource.transaction(async (manager) => {
       // 1. UserAsset 생성
-      console.log('🔍 1. Creating new UserAsset...');
-      console.log('🔍 UserAsset data:');
-      console.log('   category_id:', categoryId);
-      console.log('   asset_id:', assetId);
-      console.log('   institution_id:', institution_id);
-      console.log('   currency_code_id:', currency_code_id);
-      console.log('   avg_price:', price, '→', price.toString());
-      console.log('   quantity:', quantity, '→', quantity.toString());
-
       const userAsset = await manager.create(UserAsset, {
         category_id: categoryId,
         asset_id: assetId,
@@ -339,13 +111,9 @@ export class AssetHistoryRepository {
         deleted: false,
       });
 
-      console.log('📊 Created UserAsset entity:', userAsset);
-
       await manager.save(userAsset);
-      console.log('✅ UserAsset saved to database');
 
       // 2. 생성된 UserAsset 조회 (institution_id, currency_code_id 포함)
-      console.log('🔍 2. Fetching created UserAsset...');
       const findUserAsset = await manager.findOne(UserAsset, {
         where: {
           category_id: categoryId,
@@ -355,25 +123,18 @@ export class AssetHistoryRepository {
         },
       });
 
-      console.log('�� Found created UserAsset:', findUserAsset);
-
       if (!findUserAsset) {
-        console.log('❌ Created UserAsset not found!');
         throw new Error('UserAsset not found');
       }
 
       // 3. 거래내역 생성
-      console.log('🔍 3. Creating AssetHistory for new UserAsset...');
       const assetHistory = await this.createAssetHistory(
         createAssetHistoryRequestDto,
         findUserAsset.id,
         manager, // 기존 트랜잭션의 manager 전달
       );
 
-      console.log('📊 AssetHistory created:', assetHistory);
-
       // 4. 동일한 구조로 반환
-      console.log('🔍 4. Preparing response data...');
       const responseData = {
         asset_id: findUserAsset.asset_id,
         category_id: findUserAsset.category_id,
@@ -388,9 +149,6 @@ export class AssetHistoryRepository {
         updated_at: assetHistory.updated_at,
       };
 
-      console.log('📊 Response data prepared:', responseData);
-      console.log('🔍 === createUserAssetAndAssetHistory END ===');
-
       return responseData;
     });
   }
@@ -402,92 +160,42 @@ export class AssetHistoryRepository {
     quantity: number,
     manager?: any, // 기존 트랜잭션의 manager를 받을 수 있도록
   ) {
-    console.log('🔍 === updateUserAssetQuantity START ===');
-    console.log('📊 Input Parameters:');
-    console.log('  userAssetId:', userAssetId, '(', typeof userAssetId, ')');
-    console.log(
-      '  assetHistoryTypeId:',
-      assetHistoryTypeId,
-      '(',
-      typeof assetHistoryTypeId,
-      ')',
-    );
-    console.log('  quantity:', quantity, '(', typeof quantity, ')');
-
     // 트랜잭션 실행 함수
     const executeInTransaction = async (transactionManager: any) => {
       const userAsset = await transactionManager.findOne(UserAsset, {
         where: { id: userAssetId },
       });
 
-      console.log('📊 Found UserAsset for quantity update:', userAsset);
-
       if (!userAsset) {
-        console.log('❌ UserAsset not found for quantity update!');
         throw new Error('UserAsset not found');
       }
 
       const currentQuantity = Number(userAsset.quantity);
-      console.log('📊 Current quantity:', currentQuantity);
-      console.log('�� Quantity to change:', quantity);
-
       let newQuantity: number;
 
       if (assetHistoryTypeId === 1) {
         newQuantity = currentQuantity + quantity;
-        console.log('🔍 BUY transaction: adding quantity');
-        console.log(
-          '   Current:',
-          currentQuantity,
-          '+',
-          quantity,
-          '=',
-          newQuantity,
-        );
       } else if (assetHistoryTypeId === 2) {
         newQuantity = currentQuantity - quantity;
-        console.log('🔍 SELL transaction: subtracting quantity');
-        console.log(
-          '   Current:',
-          currentQuantity,
-          '-',
-          quantity,
-          '=',
-          newQuantity,
-        );
 
         if (newQuantity < 0) {
-          console.log('❌ Quantity cannot be negative!');
           throw new Error('Quantity cannot be negative');
         }
       } else {
-        console.log('🔍 Not buy/sell transaction, skipping quantity update');
         return;
       }
-
-      console.log(
-        '�� Updating UserAsset quantity from',
-        currentQuantity,
-        'to',
-        newQuantity,
-      );
 
       await transactionManager.update(UserAsset, userAssetId, {
         quantity: newQuantity.toString(),
       });
-
-      console.log('✅ UserAsset quantity updated successfully');
-      console.log('🔍 === updateUserAssetQuantity END ===');
 
       return newQuantity;
     };
 
     // manager가 있으면 기존 트랜잭션 사용, 없으면 새 트랜잭션 생성
     if (manager) {
-      console.log('🔍 Using existing transaction manager for quantity update');
       return await executeInTransaction(manager);
     } else {
-      console.log('🔍 Creating new transaction for quantity update');
       return this.dataSource.transaction(executeInTransaction);
     }
   }

--- a/src/modules/portfolio/asset-history/asset-history.service.ts
+++ b/src/modules/portfolio/asset-history/asset-history.service.ts
@@ -2,11 +2,13 @@ import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { AssetHistoryRepository } from './asset-history.repository';
 import { CreateAssetHistoryRequestDto } from '../dto';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
+import { PortfolioValidator } from '../lib/portfolio-validator';
 
 @Injectable()
 export class AssetHistoryService {
   constructor(
     private readonly assetHistoryRepository: AssetHistoryRepository,
+    private readonly portfolioValidator: PortfolioValidator,
   ) {}
 
   async createAssetHistory(
@@ -22,12 +24,10 @@ export class AssetHistoryService {
       // 3. UserAsset에 자산 존재여부 확인
       // 4. UserAsset 존재 여부 확인
       const validationResult =
-        await this.assetHistoryRepository.validatePortfolioAndFindUserAsset(
+        await this.portfolioValidator.validatePortfolioAndFindUserAsset(
           portfolioId,
           categoryId,
           assetId,
-          createAssetHistoryRequestDto.institution_id,
-          createAssetHistoryRequestDto.currency_code_id,
           userId,
         );
 

--- a/src/modules/portfolio/asset/asset.controller.ts
+++ b/src/modules/portfolio/asset/asset.controller.ts
@@ -1,7 +1,36 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Delete, Param, UseGuards } from '@nestjs/common';
 import { AssetService } from './asset.service';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import {
+  ApiAssetParams,
+  ApiCommonErrorResponsesWithNotFound,
+  ApiDeleteAssetResponse,
+} from 'src/common/swagger';
+import { DeleteAssetParamDto, DeleteAssetResponseDto } from '../dto';
+import { JwtAuthGuard } from 'src/modules/auth/guards';
+import { User } from 'src/modules/auth/decorators/user.decorator';
 
-@Controller('asset')
+@ApiTags('portfolios')
+@ApiBearerAuth()
+@Controller('portfolios')
 export class AssetController {
   constructor(private readonly assetService: AssetService) {}
+
+  @Delete(':portfolio_id/categories/:category_id/assets/:asset_id')
+  @ApiOperation({ summary: '자산 삭제' })
+  @ApiAssetParams()
+  @ApiDeleteAssetResponse()
+  @ApiCommonErrorResponsesWithNotFound()
+  @UseGuards(JwtAuthGuard)
+  async deleteAsset(
+    @Param() deleteAssetParamDto: DeleteAssetParamDto,
+    @User() user: any,
+  ): Promise<DeleteAssetResponseDto> {
+    return await this.assetService.deleteAsset(
+      Number(deleteAssetParamDto.portfolio_id),
+      Number(deleteAssetParamDto.category_id),
+      Number(deleteAssetParamDto.asset_id),
+      user.id,
+    );
+  }
 }

--- a/src/modules/portfolio/asset/asset.repository.ts
+++ b/src/modules/portfolio/asset/asset.repository.ts
@@ -1,6 +1,33 @@
 import { Injectable } from '@nestjs/common';
+import { AssetHistory } from 'src/database/entities/portfolio/asset-history.entity';
+import { UserAsset } from 'src/database/entities/portfolio/user-asset.entity';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class AssetRepository {
-  constructor() {}
+  constructor(private readonly dataSource: DataSource) {}
+
+  async deleteAsset(userAssetId: number) {
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.connect();
+    await queryRunner.startTransaction();
+
+    try {
+      // 1. AssetHistory 삭제
+      await queryRunner.manager.delete(AssetHistory, {
+        user_asset_id: userAssetId,
+      });
+
+      // 2. UserAsset 삭제
+      await queryRunner.manager.delete(UserAsset, {
+        id: userAssetId,
+      });
+
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+    } catch (error) {
+      await queryRunner.rollbackTransaction();
+      throw error;
+    }
+  }
 }

--- a/src/modules/portfolio/asset/asset.service.ts
+++ b/src/modules/portfolio/asset/asset.service.ts
@@ -1,4 +1,76 @@
-import { Injectable } from '@nestjs/common';
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { AssetRepository } from './asset.repository';
+import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
+import { PortfolioValidator } from '../lib/portfolio-validator';
 
 @Injectable()
-export class AssetService {}
+export class AssetService {
+  constructor(
+    private readonly assetRepository: AssetRepository,
+    private readonly portfolioValidator: PortfolioValidator,
+  ) {}
+
+  async deleteAsset(
+    portfolioId: number,
+    categoryId: number,
+    assetId: number,
+    userId: string,
+  ) {
+    try {
+      const validationResult =
+        await this.portfolioValidator.validatePortfolioAndFindUserAsset(
+          portfolioId,
+          categoryId,
+          assetId,
+          userId,
+        );
+
+      const { userAsset } = validationResult;
+
+      if (!userAsset) {
+        throw new Error('UserAsset not found');
+      }
+
+      await this.assetRepository.deleteAsset(userAsset.id);
+
+      return {
+        success: true,
+        message: 'Asset deleted successfully',
+        data: {
+          asset_id: assetId,
+          deleted_at: new Date().toISOString(),
+        },
+      };
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Category not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Asset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'UserAsset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('UserAsset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/modules/portfolio/dto/requests/asset/delete-asset.dto.ts
+++ b/src/modules/portfolio/dto/requests/asset/delete-asset.dto.ts
@@ -1,19 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt, Min } from 'class-validator';
+import { IsString } from 'class-validator';
 
 export class DeleteAssetParamDto {
   @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  portfolio_id: number;
+  @IsString()
+  portfolio_id: string;
 
   @ApiProperty({ description: '카테고리 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  category_id: number;
+  @IsString()
+  category_id: string;
 
   @ApiProperty({ description: '자산 ID', example: 1 })
-  @IsInt()
-  @Min(1)
-  asset_id: number;
+  @IsString()
+  asset_id: string;
 }

--- a/src/modules/portfolio/lib/portfolio-validator.ts
+++ b/src/modules/portfolio/lib/portfolio-validator.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@nestjs/common';
+import { Asset } from 'src/database/entities/asset/asset.entity';
+import { Category } from 'src/database/entities/portfolio/category.entity';
+import { Portfolio } from 'src/database/entities/portfolio/portfolio.entity';
+import { UserAsset } from 'src/database/entities/portfolio/user-asset.entity';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class PortfolioValidator {
+  constructor(private dataSource: DataSource) {}
+
+  async validatePortfolioAndFindUserAsset(
+    portfolioId: number,
+    categoryId: number,
+    assetId: number,
+    userId: string,
+  ) {
+    return this.dataSource.transaction(async (manager) => {
+      // 1. 포트폴리오 소유권 검증
+      const portfolio = await manager.findOne(Portfolio, {
+        where: { id: portfolioId, user_id: userId },
+      });
+
+      if (!portfolio) {
+        throw new Error('Portfolio not found');
+      }
+
+      // 2. 카테고리 소유권 검증
+      const category = await manager.findOne(Category, {
+        where: { id: categoryId, portfolio_id: portfolioId },
+      });
+
+      if (!category) {
+        throw new Error('Category not found');
+      }
+
+      // 3. 자산 존재 여부
+      const asset = await manager.findOne(Asset, {
+        where: { id: assetId },
+      });
+
+      if (!asset) {
+        throw new Error('Asset not found');
+      }
+
+      // 4. UserAsset 존재 여부
+      const userAsset = await manager.findOne(UserAsset, {
+        where: {
+          asset_id: assetId,
+          category_id: categoryId,
+        },
+      });
+
+      return {
+        portfolio,
+        category,
+        asset,
+        userAsset,
+      };
+    });
+  }
+}

--- a/src/modules/portfolio/portfolio.module.ts
+++ b/src/modules/portfolio/portfolio.module.ts
@@ -29,6 +29,7 @@ import { User } from 'src/database/entities/user/user.entity';
 import { StockInfo } from 'src/database/entities/stock/stock-info.entity';
 import { CryptoInfo } from 'src/database/entities/crypto/crypto-info.entity';
 import { EtfInfo } from 'src/database/entities/etf/etf-info.entity';
+import { PortfolioValidator } from './lib/portfolio-validator';
 
 @Module({
   imports: [
@@ -59,12 +60,14 @@ import { EtfInfo } from 'src/database/entities/etf/etf-info.entity';
     CategoryRepository,
     AssetRepository,
     AssetHistoryRepository,
+    PortfolioValidator,
   ],
   exports: [
     PortfolioService,
     CategoryService,
     AssetService,
     AssetHistoryService,
+    PortfolioValidator,
   ],
 })
 export class PortfolioModule {}

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -20,31 +20,22 @@ import {
   ApiCommonErrorResponses,
   ApiCommonErrorResponsesWithNotFound,
   ApiPortfolioParam,
-  ApiCategoryParams,
-  ApiAssetParams,
   ApiHistoryParams,
   ApiGetAllPortfolioResponse,
   ApiCreatePortfolio,
   ApiDeletePortfolioResponse,
   ApiUpdatePortfolio,
   ApiGetPortfolioSummaryResponse,
-  ApiCreateAssetHistory,
-  ApiDeleteAssetResponse,
   ApiGetAssetHistoryResponse,
   ApiDeleteAssetHistoryResponse,
   ApiUpdateAssetHistory,
 } from 'src/common/swagger';
 
 import {
-  CreateAssetHistoryParamDto,
-  CreateAssetHistoryRequestDto,
-  CreateAssetHistoryResponseDto,
   CreatePortfolioRequestDto,
   CreatePortfolioResponseDto,
   DeleteAssetHistoryParamsDto,
   DeleteAssetHistoryResponseDto,
-  DeleteAssetParamDto,
-  DeleteAssetResponseDto,
   DeletePortfolioParamDto,
   DeletePortfolioResponseDto,
   GetAllPortfolioResponseDto,
@@ -140,27 +131,6 @@ export class PortfolioController {
       Number(getPortfolioSummaryParamDto.portfolio_id),
       user.id,
     );
-  }
-
-
-
-  @Delete(':portfolio_id/categories/:category_id/assets/:asset_id')
-  @ApiOperation({ summary: '자산 삭제' })
-  @ApiAssetParams()
-  @ApiDeleteAssetResponse()
-  @ApiCommonErrorResponsesWithNotFound()
-  async deleteAsset(
-    @Param() deleteAssetParamDto: DeleteAssetParamDto,
-  ): Promise<DeleteAssetResponseDto> {
-    const mockData: DeleteAssetResponseDto = {
-      success: true,
-      message: 'Asset deleted successfully.',
-      data: {
-        asset_id: 102,
-        deleted_at: '2025-07-03T13:10:45.000Z',
-      },
-    };
-    return mockData;
   }
 
   @Get(':portfolio_id/categories/:category_id/assets/:asset_id/histories')


### PR DESCRIPTION
✨ 구현된 기능
사용자가 포트폴리오의 특정 카테고리에서 특정 자산을 삭제할 수 있는 기능을 구현했습니다.

## 주요 변경사항
- **API 엔드포인트**: DELETE /api/portfolios/{id}/categories/{id}/assets/{id}
- **공통 검증 로직**: PortfolioValidator를 통한 도메인별 검증 로직 분리
- **Hard Delete 구현**: Soft Delete 대신 완전한 데이터 삭제 전략 적용
- **트랜잭션 관리**: UserAsset과 AssetHistory의 CASCADE 삭제 보장
- **에러 처리**: 이미 삭제된 자산에 대한 적절한 404 응답

## 핵심 기능
- 자산 삭제 시 관련 거래내역 자동 삭제
- 포트폴리오/카테고리/자산 소유권 검증
- JWT 인증을 통한 보안 강화
- 데이터 무결성 보장을 위한 트랜잭션 처리

## ✅ 체크리스트
- [x] 자산 삭제 API 구현
- [x] 공통 검증 로직 분리
- [x] Hard Delete 전략 적용
- [x] 에러 응답 표준화
- [x] 트랜잭션 일관성 보장