### PR TITLE
Feat#48 거래내역 삭제 기능 구현

### DIFF
--- a/src/modules/portfolio/asset-history/asset-history.controller.ts
+++ b/src/modules/portfolio/asset-history/asset-history.controller.ts
@@ -1,6 +1,7 @@
 import {
   Body,
   Controller,
+  Delete,
   Get,
   Param,
   Post,
@@ -12,12 +13,17 @@ import { ApiOperation } from '@nestjs/swagger';
 import {
   ApiCategoryParams,
   ApiCommonErrorResponses,
+  ApiCommonErrorResponsesWithNotFound,
   ApiCreateAssetHistory,
+  ApiDeleteAssetHistoryResponse,
+  ApiHistoryParams,
 } from 'src/common/swagger';
 import {
   CreateAssetHistoryParamDto,
   CreateAssetHistoryRequestDto,
   CreateAssetHistoryResponseDto,
+  DeleteAssetHistoryParamDto,
+  DeleteAssetHistoryResponseDto,
   GetAssetHistoryParamDto,
   GetAssetHistoryQueryDto,
   GetAssetHistoryResponseDto,
@@ -64,6 +70,27 @@ export class AssetHistoryController {
       Number(createAssetHistoryParamDto.category_id),
       Number(createAssetHistoryParamDto.asset_id),
       createAssetHistoryRequestDto,
+      user.id,
+    );
+  }
+
+  @Delete(
+    ':portfolio_id/categories/:category_id/assets/:asset_id/histories/:history_id',
+  )
+  @ApiOperation({ summary: '거래내역 삭제' })
+  @ApiHistoryParams()
+  @ApiDeleteAssetHistoryResponse()
+  @ApiCommonErrorResponsesWithNotFound()
+  @UseGuards(JwtAuthGuard)
+  async deleteAssetHistory(
+    @Param() deleteAssetHistoryParamsDto: DeleteAssetHistoryParamDto,
+    @User() user: any,
+  ): Promise<DeleteAssetHistoryResponseDto> {
+    return await this.assetHistoryService.deleteAssetHistory(
+      Number(deleteAssetHistoryParamsDto.portfolio_id),
+      Number(deleteAssetHistoryParamsDto.category_id),
+      Number(deleteAssetHistoryParamsDto.asset_id),
+      Number(deleteAssetHistoryParamsDto.history_id),
       user.id,
     );
   }

--- a/src/modules/portfolio/asset-history/asset-history.repository.ts
+++ b/src/modules/portfolio/asset-history/asset-history.repository.ts
@@ -293,7 +293,7 @@ export class AssetHistoryRepository {
         institution_id,
         currency_code_id,
         avg_price: price.toString(),
-        quantity: quantity.toString(),
+        quantity: '0',
         eval_amount: '0',
         profit_loss: '0',
         profit_rate: '0',
@@ -387,6 +387,62 @@ export class AssetHistoryRepository {
       return await executeInTransaction(manager);
     } else {
       return this.dataSource.transaction(executeInTransaction);
+    }
+  }
+
+  async getAssetHistory(historyId: number) {
+    return await this.dataSource.manager.findOne(AssetHistory, {
+      where: { id: historyId },
+    });
+  }
+
+  async deleteAssetHistory(historyId: number, manager: any) {
+    return await manager.delete(AssetHistory, { id: historyId });
+  }
+
+  async updateUserAssetQuantityForDelete(
+    userAssetId: number,
+    assetHistoryTypeId: number,
+    quantity: number,
+    manager: any,
+  ) {
+    const executeInTransaction = async (transactionManager: any) => {
+      const userAsset = await transactionManager.findOne(UserAsset, {
+        where: { id: userAssetId },
+      });
+
+      if (!userAsset) {
+        throw new Error('UserAsset not found');
+      }
+
+      const currentQuantity = Number(userAsset.quantity);
+      let newQuantity: number;
+
+      if (assetHistoryTypeId === 1) {
+        // 매수 거래 삭제 -> 수량 차감
+        newQuantity = currentQuantity - quantity;
+      } else if (assetHistoryTypeId === 2) {
+        // 매도 거래 삭제 -> 수량 증가
+        newQuantity = currentQuantity + quantity;
+
+        if (newQuantity < 0) {
+          throw new Error('Quantity cannot be negative');
+        }
+      } else {
+        return;
+      }
+
+      await transactionManager.update(UserAsset, userAssetId, {
+        quantity: newQuantity.toString(),
+      });
+
+      return newQuantity;
+    };
+
+    if (manager) {
+      return await executeInTransaction(manager); // 기존 트랜잭션 사용
+    } else {
+      return this.dataSource.transaction(executeInTransaction); // 새 트랜잭션 생성
     }
   }
 }

--- a/src/modules/portfolio/asset-history/asset-history.service.ts
+++ b/src/modules/portfolio/asset-history/asset-history.service.ts
@@ -3,12 +3,16 @@ import { AssetHistoryRepository } from './asset-history.repository';
 import { CreateAssetHistoryRequestDto, GetAssetHistoryQueryDto } from '../dto';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 import { PortfolioValidator } from '../lib/portfolio-validator';
+import { DataSource } from 'typeorm';
+import { UserAsset } from 'src/database/entities/portfolio/user-asset.entity';
+import { AssetHistory } from 'src/database/entities/portfolio/asset-history.entity';
 
 @Injectable()
 export class AssetHistoryService {
   constructor(
     private readonly assetHistoryRepository: AssetHistoryRepository,
     private readonly portfolioValidator: PortfolioValidator,
+    private readonly dataSource: DataSource,
   ) {}
 
   async getAssetHistories(
@@ -129,9 +133,6 @@ export class AssetHistoryService {
           data: result,
         };
       }
-
-      // 5. 수량 업데이트 로직
-      // 6. 총 거래금액 계산
     } catch (error) {
       if (error.message === 'Portfolio not found') {
         throw new HttpException(
@@ -162,6 +163,107 @@ export class AssetHistoryService {
       }
 
       throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  async deleteAssetHistory(
+    portfolioId: number,
+    categoryId: number,
+    assetId: number,
+    historyId: number,
+    userId: string,
+  ) {
+    try {
+      // 1. 포트폴리오, 카테고리, 자산 소유권 검증
+      await this.portfolioValidator.validatePortfolioAndFindUserAsset(
+        portfolioId,
+        categoryId,
+        assetId,
+        userId,
+      );
+
+      // 2. 거래내역 존재 여부 확인
+      const assetHistory =
+        await this.assetHistoryRepository.getAssetHistory(historyId);
+
+      if (!assetHistory) {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset history not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      return await this.dataSource.transaction(async (manager) => {
+        // 3. 거래내역 삭제
+        const result = await this.assetHistoryRepository.deleteAssetHistory(
+          historyId,
+          manager,
+        );
+
+        // 4. 수량 업데이트 로직
+        await this.assetHistoryRepository.updateUserAssetQuantityForDelete(
+          assetHistory.user_asset_id, // userAssetId
+          assetHistory.asset_history_type_id, // 거래 타입
+          Number(assetHistory.quantity), // 삭제할 수량
+          manager, // 트랜잭션 manager
+        );
+
+        // 5. UserAsset 수량이 0 AND History가 존재하지 않으면 UserAsset 삭제
+        const userAsset = await manager.findOne(UserAsset, {
+          where: { id: assetHistory.user_asset_id },
+          relations: ['asset_histories'],
+        });
+        if (Number(userAsset?.quantity) === 0) {
+          const remainingHistories = await manager.count(AssetHistory, {
+            where: { user_asset_id: userAsset?.id },
+          });
+          if (remainingHistories === 0) {
+            await manager.delete(UserAsset, { id: userAsset?.id });
+          }
+        }
+
+        return {
+          success: true,
+          message: 'Asset history deleted successfully.',
+          data: {
+            asset_history_id: historyId,
+            deleted_at: new Date().toISOString(),
+          },
+        };
+      });
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Category not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Asset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'UserAsset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('UserAsset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError('Failed to delete asset history'),
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
     }
   }
 }

--- a/src/modules/portfolio/dto/requests/asset-history/delete-asset-history.dto.ts
+++ b/src/modules/portfolio/dto/requests/asset-history/delete-asset-history.dto.ts
@@ -1,20 +1,24 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsInt } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
-export class DeleteAssetHistoryParamsDto {
-  @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  portfolio_id: number;
+export class DeleteAssetHistoryParamDto {
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '포트폴리오 ID', example: '1' })
+  portfolio_id: string;
 
-  @ApiProperty({ description: '카테고리 ID', example: 1 })
-  @IsInt()
-  category_id: number;
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '카테고리 ID', example: '1' })
+  category_id: string;
 
-  @ApiProperty({ description: '자산 ID', example: 1 })
-  @IsInt()
-  asset_id: number;
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '자산 ID', example: '1' })
+  asset_id: string;
 
-  @ApiProperty({ description: '거래내역 ID', example: 1 })
-  @IsInt()
-  history_id: number;
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '거래내역 ID', example: '1' })
+  history_id: string;
 }

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -6,16 +6,10 @@ import {
   Param,
   Post,
   Put,
-  Query,
   UseGuards,
 } from '@nestjs/common';
 import { PortfolioService } from './portfolio.service';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiQuery,
-  ApiTags,
-} from '@nestjs/swagger';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
   ApiCommonErrorResponses,
   ApiCommonErrorResponsesWithNotFound,
@@ -26,22 +20,15 @@ import {
   ApiDeletePortfolioResponse,
   ApiUpdatePortfolio,
   ApiGetPortfolioSummaryResponse,
-  ApiGetAssetHistoryResponse,
-  ApiDeleteAssetHistoryResponse,
   ApiUpdateAssetHistory,
 } from 'src/common/swagger';
 
 import {
   CreatePortfolioRequestDto,
   CreatePortfolioResponseDto,
-  DeleteAssetHistoryParamsDto,
-  DeleteAssetHistoryResponseDto,
   DeletePortfolioParamDto,
   DeletePortfolioResponseDto,
   GetAllPortfolioResponseDto,
-  GetAssetHistoryParamDto,
-  GetAssetHistoryQueryDto,
-  GetAssetHistoryResponseDto,
   GetPortfolioSummaryParamDto,
   GetPortfolioSummaryResponseDto,
   UpdateAssetHistoryParamsDto,
@@ -131,27 +118,6 @@ export class PortfolioController {
       Number(getPortfolioSummaryParamDto.portfolio_id),
       user.id,
     );
-  }
-
-  @Delete(
-    ':portfolio_id/categories/:category_id/assets/:asset_id/histories/:history_id',
-  )
-  @ApiOperation({ summary: '거래내역 삭제' })
-  @ApiHistoryParams()
-  @ApiDeleteAssetHistoryResponse()
-  @ApiCommonErrorResponsesWithNotFound()
-  async deleteAssetHistory(
-    @Param() deleteAssetHistoryParamsDto: DeleteAssetHistoryParamsDto,
-  ): Promise<DeleteAssetHistoryResponseDto> {
-    const mockData: DeleteAssetHistoryResponseDto = {
-      success: true,
-      message: 'History deleted successfully.',
-      data: {
-        asset_history_id: 555,
-        deleted_at: '2025-07-03T15:00:00.000Z',
-      },
-    };
-    return mockData;
   }
 
   @Put(


### PR DESCRIPTION
### 주요 기능
- 거래내역 삭제 API 구현
- 삭제 시 UserAsset 수량 자동 조정
- 수량이 0이고 거래내역이 없으면 UserAsset 자동 삭제

### API
- `DELETE /api/portfolios/{portfolio_id}/categories/{category_id}/assets/{asset_id}/histories/{history_id}`

### 구현 내용
- DTO 구조 정의
- Repository 로직 (삭제, 수량 업데이트)
- Service 비즈니스 로직 (검증, 트랜잭션)
- Controller API 엔드포인트
