### PR TITLE
Feat#49 거래내역 수정 기능 구현

### DIFF
--- a/src/modules/portfolio/asset-history/asset-history.controller.ts
+++ b/src/modules/portfolio/asset-history/asset-history.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   Param,
   Post,
+  Put,
   Query,
   UseGuards,
 } from '@nestjs/common';
@@ -17,6 +18,7 @@ import {
   ApiCreateAssetHistory,
   ApiDeleteAssetHistoryResponse,
   ApiHistoryParams,
+  ApiUpdateAssetHistory,
 } from 'src/common/swagger';
 import {
   CreateAssetHistoryParamDto,
@@ -27,6 +29,9 @@ import {
   GetAssetHistoryParamDto,
   GetAssetHistoryQueryDto,
   GetAssetHistoryResponseDto,
+  UpdateAssetHistoryParamDto,
+  UpdateAssetHistoryRequestDto,
+  UpdateAssetHistoryResponseDto,
 } from '../dto';
 import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
@@ -91,6 +96,29 @@ export class AssetHistoryController {
       Number(deleteAssetHistoryParamsDto.category_id),
       Number(deleteAssetHistoryParamsDto.asset_id),
       Number(deleteAssetHistoryParamsDto.history_id),
+      user.id,
+    );
+  }
+
+  @Put(
+    ':portfolio_id/categories/:category_id/assets/:asset_id/histories/:history_id',
+  )
+  @ApiOperation({ summary: '거래내역 수정' })
+  @ApiHistoryParams()
+  @ApiUpdateAssetHistory()
+  @ApiCommonErrorResponsesWithNotFound()
+  @UseGuards(JwtAuthGuard)
+  async updateAssetHistory(
+    @Param() updateAssetHistoryParamsDto: UpdateAssetHistoryParamDto,
+    @Body() updateAssetHistoryRequestDto: UpdateAssetHistoryRequestDto,
+    @User() user: any,
+  ): Promise<UpdateAssetHistoryResponseDto> {
+    return await this.assetHistoryService.updateAssetHistory(
+      Number(updateAssetHistoryParamsDto.portfolio_id),
+      Number(updateAssetHistoryParamsDto.category_id),
+      Number(updateAssetHistoryParamsDto.asset_id),
+      Number(updateAssetHistoryParamsDto.history_id),
+      updateAssetHistoryRequestDto,
       user.id,
     );
   }

--- a/src/modules/portfolio/asset-history/asset-history.repository.ts
+++ b/src/modules/portfolio/asset-history/asset-history.repository.ts
@@ -1,7 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { UserAsset } from 'src/database/entities/portfolio/user-asset.entity';
 import { DataSource } from 'typeorm';
-import { CreateAssetHistoryRequestDto, GetAssetHistoryQueryDto } from '../dto';
+import {
+  CreateAssetHistoryRequestDto,
+  GetAssetHistoryQueryDto,
+  UpdateAssetHistoryRequestDto,
+} from '../dto';
 import { AssetHistory } from 'src/database/entities/portfolio/asset-history.entity';
 import { StockInfo } from 'src/database/entities/stock/stock-info.entity';
 import { EtfInfo } from 'src/database/entities/etf/etf-info.entity';
@@ -155,6 +159,17 @@ export class AssetHistoryRepository {
       3: 'crypto',
     };
     return typeMap[assetTypeId] || 'unknown';
+  }
+
+  private getTypeNameById(typeId: number): string {
+    const map: Record<number, string> = {
+      1: 'buy',
+      2: 'sell',
+      3: 'deposit',
+      4: 'withdraw',
+      5: 'exchange',
+    };
+    return map[typeId] || 'unknown';
   }
 
   private async getAssetHistorySummary(userAssetId: number, manager: any) {
@@ -398,6 +413,164 @@ export class AssetHistoryRepository {
 
   async deleteAssetHistory(historyId: number, manager: any) {
     return await manager.delete(AssetHistory, { id: historyId });
+  }
+
+  async updateAssetHistory(
+    historyId: number,
+    dto: UpdateAssetHistoryRequestDto,
+  ) {
+    const {
+      asset_history_type_id: newTypeId,
+      price: newPrice,
+      quantity: newQty,
+      memo: newMemo,
+      recorded_at: newRecordedAt,
+      institution_id,
+      currency_code_id,
+    } = dto;
+
+    return this.dataSource.transaction(async (manager) => {
+      // 1) 기존 거래내역 + 관련 UserAsset 로드
+      const existing = await manager.findOne(AssetHistory, {
+        where: { id: historyId },
+      });
+
+      if (!existing) {
+        throw new Error('Asset history not found');
+      }
+
+      const userAsset = await manager.findOne(UserAsset, {
+        where: { id: existing.user_asset_id },
+        relations: [
+          'category',
+          'category.portfolio',
+          'asset',
+          'institution',
+          'currency_code',
+        ],
+      });
+
+      if (!userAsset) {
+        throw new Error('UserAsset not found');
+      }
+
+      // 2) 수량 변화량 계산 (buy=+qty, sell=-qty; 기타 타입 0)
+      const oldTypeId = existing.asset_history_type_id;
+      const oldQty = Number(existing.quantity);
+      const currentQty = Number(userAsset.quantity);
+
+      const effect = (typeId: number, qty: number) => {
+        if (typeId === 1) return qty; // buy
+        if (typeId === 2) return -qty; // sell
+        return 0; // deposit/withdraw/exchange는 수량 영향 없음
+      };
+
+      /**
+       * 기존 매수 (1, 10)
+       * 수정 매도 (2, 20)
+       * effect(2, 20) - effect(1, 10) = -10
+       * nextUserAssetQty = currentQty + delta = 0 - 10 = -10
+       * -10 < 0 -> throw Error
+       *
+       * 기존 매도 (2, 20)
+       * 수정 매수 (1, 10)
+       * effect(1, 10) - effect(2, 20) = 10
+       * nextUserAssetQty = currentQty + delta = 0 + 10 = 10
+       * 10 > 0 -> update UserAsset
+       */
+      const delta = effect(newTypeId, newQty) - effect(oldTypeId, oldQty);
+      const nextUserAssetQty = currentQty + delta;
+
+      if (nextUserAssetQty < 0) {
+        throw new Error('Quantity cannot be negative');
+      }
+
+      // 3) UserAsset 업데이트 (수량, 기관/통화 변경)
+      await manager.update(UserAsset, userAsset.id, {
+        quantity: nextUserAssetQty.toString(),
+        institution_id: institution_id ?? userAsset.institution_id,
+        currency_code_id: currency_code_id ?? userAsset.currency_code_id,
+        // TODO: avg_price 재계산은 추후 공통 함수로 처리 예정
+      });
+
+      // 4) 거래내역 업데이트
+      const updatedTotal = (newPrice * newQty).toString();
+      await manager.update(AssetHistory, existing.id, {
+        asset_history_type_id: newTypeId,
+        price: newPrice.toString(),
+        quantity: newQty.toString(),
+        total_amount: updatedTotal,
+        recorded_at: new Date(newRecordedAt),
+        memo: newMemo ?? undefined,
+      });
+
+      // 5) 응답 구성에 필요한 이름/타입 문자열 준비
+      // 자산 이름 조회
+      let assetName = '';
+      switch (userAsset.asset.asset_type_id) {
+        case 1: {
+          const stockInfo = await manager.findOne(StockInfo, {
+            where: { id: userAsset.asset.asset_info_id },
+          });
+          assetName = stockInfo?.kor_name || stockInfo?.eng_name || '';
+          break;
+        }
+        case 2: {
+          const etfInfo = await manager.findOne(EtfInfo, {
+            where: { id: userAsset.asset.asset_info_id },
+          });
+          assetName = etfInfo?.kor_name || etfInfo?.eng_name || '';
+          break;
+        }
+        case 3: {
+          const cryptoInfo = await manager.findOne(CryptoInfo, {
+            where: { id: userAsset.asset.asset_info_id },
+          });
+          assetName = cryptoInfo?.kor_name || cryptoInfo?.eng_name || '';
+          break;
+        }
+        default:
+          assetName = '';
+      }
+
+      const typeName = this.getTypeNameById(newTypeId);
+
+      // 6) 응답 객체 구성
+      return {
+        asset_info: {
+          asset_id: userAsset.asset_id,
+          asset_name: assetName,
+          asset_type: this.getAssetTypeName(userAsset.asset.asset_type_id),
+        },
+        portfolio_info: {
+          portfolio_id: userAsset.category.portfolio_id,
+          portfolio_name: userAsset.category.portfolio?.name || '',
+        },
+        category_info: {
+          category_id: userAsset.category_id,
+          category_name: userAsset.category?.name || '',
+        },
+        institution_info: {
+          institution_id: institution_id ?? userAsset.institution_id,
+          institution_name: userAsset.institution?.display_name || '',
+        },
+        currency_info: {
+          currency_code_id: currency_code_id ?? userAsset.currency_code_id,
+          currency_code: userAsset.currency_code?.currency_code || 'KRW',
+        },
+        updated_history: {
+          asset_history_id: existing.id,
+          asset_history_type_id: newTypeId,
+          type_name: typeName,
+          quantity: newQty,
+          price: newPrice,
+          total_amount: Number(updatedTotal),
+          recorded_at: new Date(newRecordedAt).toISOString(),
+          memo: newMemo ?? null,
+          updated_at: new Date().toISOString(),
+        },
+      };
+    });
   }
 
   async updateUserAssetQuantityForDelete(

--- a/src/modules/portfolio/asset-history/asset-history.service.ts
+++ b/src/modules/portfolio/asset-history/asset-history.service.ts
@@ -1,6 +1,10 @@
 import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
 import { AssetHistoryRepository } from './asset-history.repository';
-import { CreateAssetHistoryRequestDto, GetAssetHistoryQueryDto } from '../dto';
+import {
+  CreateAssetHistoryRequestDto,
+  GetAssetHistoryQueryDto,
+  UpdateAssetHistoryRequestDto,
+} from '../dto';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 import { PortfolioValidator } from '../lib/portfolio-validator';
 import { DataSource } from 'typeorm';
@@ -264,6 +268,97 @@ export class AssetHistoryService {
         ErrorResponseUtil.internalServerError('Failed to delete asset history'),
         HttpStatus.INTERNAL_SERVER_ERROR,
       );
+    }
+  }
+
+  async updateAssetHistory(
+    portfolioId: number,
+    categoryId: number,
+    assetId: number,
+    historyId: number,
+    updateAssetHistoryRequestDto: UpdateAssetHistoryRequestDto,
+    userId: string,
+  ) {
+    try {
+      // 1) 포트폴리오, 카테고리, 자산 소유권 검증 및 UserAsset 확인
+      const { userAsset } =
+        await this.portfolioValidator.validatePortfolioAndFindUserAsset(
+          portfolioId,
+          categoryId,
+          assetId,
+          userId,
+        );
+
+      // 2) 거래내역 존재 여부 확인 및 소유권 검증
+      const existing = await this.assetHistoryRepository.getAssetHistory(
+        historyId,
+      );
+      if (!existing) {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset history not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (userAsset && existing.user_asset_id !== userAsset.id) {
+        // 경로상의 자산/카테고리와 거래내역의 소유관계가 다르면 Not Found 처리
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset history not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      // 3) 트랜잭션으로 업데이트 (수량 조정 + 거래내역 업데이트)
+      const data = await this.assetHistoryRepository.updateAssetHistory(
+        historyId,
+        updateAssetHistoryRequestDto,
+      );
+
+      return {
+        success: true,
+        message: 'Asset history updated successfully.',
+        data,
+      };
+    } catch (error) {
+      if (error.message === 'Portfolio not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Category not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Category not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'Asset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Asset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (error.message === 'UserAsset not found') {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('UserAsset not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      if (
+        error.message === 'Asset history not found' ||
+        error.message === 'Quantity cannot be negative'
+      ) {
+        throw new HttpException(
+          ErrorResponseUtil.badRequest(error.message),
+          HttpStatus.BAD_REQUEST,
+        );
+      }
+
+      throw new HttpException(error.message, HttpStatus.INTERNAL_SERVER_ERROR);
     }
   }
 }

--- a/src/modules/portfolio/dto/requests/asset-history/update-asset-history.dto.ts
+++ b/src/modules/portfolio/dto/requests/asset-history/update-asset-history.dto.ts
@@ -1,75 +1,97 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsDateString,
-  IsEnum,
   IsInt,
   IsNumber,
-  IsObject,
+  IsISO8601,
   IsOptional,
   IsString,
+  Min,
 } from 'class-validator';
-import { CurrencyCode, TradeType } from '../asset/create-asset-history.dto';
-import { ApiProperty } from '@nestjs/swagger';
 
-export class UpdateAssetHistoryParamsDto {
-  @ApiProperty({ description: '포트폴리오 ID', example: 1 })
-  @IsInt()
-  portfolio_id: number;
-
-  @ApiProperty({ description: '카테고리 ID', example: 1 })
-  @IsInt()
-  category_id: number;
-
-  @ApiProperty({ description: '자산 ID', example: 1 })
-  @IsInt()
-  asset_id: number;
-
-  @ApiProperty({ description: '거래내역 ID', example: 1 })
-  @IsInt()
-  history_id: number;
-}
-
-export class UpdateHistoryItem {
-  @ApiProperty({ description: '거래 유형', example: 'buy' })
-  @IsEnum(TradeType)
-  type: TradeType;
-
-  @ApiProperty({ description: '거래 수량', example: 100 })
-  @IsInt()
-  quantity: number;
-
-  @ApiProperty({ description: '거래 가격', example: 10000 })
-  @IsNumber()
-  price: number;
-
-  @ApiProperty({ description: '거래 일시', example: '2021-01-01' })
-  @IsDateString()
-  recorded_at: string;
-
-  @ApiProperty({ description: '메모', example: '거래 메모' })
-  @IsOptional()
+export class UpdateAssetHistoryParamDto {
+  @ApiProperty({
+    description: '포트폴리오 ID',
+    example: '7',
+  })
   @IsString()
-  memo?: string;
+  portfolio_id: string;
+
+  @ApiProperty({
+    description: '카테고리 ID',
+    example: '2',
+  })
+  @IsString()
+  category_id: string;
+
+  @ApiProperty({
+    description: '자산 ID',
+    example: '2321',
+  })
+  @IsString()
+  asset_id: string;
+
+  @ApiProperty({
+    description: '거래내역 ID',
+    example: '112',
+  })
+  @IsString()
+  history_id: string;
 }
 
 export class UpdateAssetHistoryRequestDto {
-  @ApiProperty({ description: '기관 ID', example: 1 })
+  @ApiProperty({
+    description: '거래소/증권사 ID',
+    example: 2,
+  })
   @IsInt()
+  @Min(1)
   institution_id: number;
 
-  @ApiProperty({ description: '통화 코드', example: 'KRW' })
-  @IsEnum(CurrencyCode)
-  curreny_code: CurrencyCode;
+  @ApiProperty({
+    description: '통화 코드 ID',
+    example: 1,
+  })
+  @IsInt()
+  @Min(1)
+  currency_code_id: number;
 
   @ApiProperty({
-    description: '거래내역',
-    example: {
-      type: 'buy',
-      quantity: 100,
-      price: 10000,
-      recorded_at: '2021-01-01',
-      memo: '거래 메모',
-    },
+    description: '거래 타입 ID (1: 매수, 2: 매도, 3: 입금, 4: 출금, 5: 교환)',
+    example: 1,
   })
-  @IsObject()
-  histories: UpdateHistoryItem;
+  @IsInt()
+  @Min(1)
+  asset_history_type_id: number;
+
+  @ApiProperty({
+    description: '거래 가격',
+    example: 23000,
+  })
+  @IsNumber()
+  @Min(0)
+  price: number;
+
+  @ApiProperty({
+    description: '거래 수량',
+    example: 10,
+  })
+  @IsInt()
+  @Min(1)
+  quantity: number;
+
+  @ApiProperty({
+    description: '거래 일시 (ISO 8601 형식)',
+    example: '2024-01-15T14:30:00Z',
+  })
+  @IsISO8601()
+  recorded_at: string;
+
+  @ApiProperty({
+    description: '메모',
+    example: '7월 매수',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  memo?: string;
 }

--- a/src/modules/portfolio/dto/responses/asset-history/update-asset-history.dto.ts
+++ b/src/modules/portfolio/dto/responses/asset-history/update-asset-history.dto.ts
@@ -1,57 +1,192 @@
 import { ApiProperty } from '@nestjs/swagger';
 
-export class EditedHistory {
-  asset_history_id: number;
-  type: string;
-  quantity: number;
-  price: number;
-  total: number;
-  recorded_at: string;
-  memo?: string;
+export class UpdateAssetInfo {
+  @ApiProperty({
+    description: '자산 ID',
+    example: 102,
+  })
+  asset_id: number;
+
+  @ApiProperty({
+    description: '자산 이름',
+    example: '삼성전자',
+  })
+  asset_name: string;
+
+  @ApiProperty({
+    description: '자산 타입',
+    example: 'stock',
+  })
+  asset_type: string;
 }
 
-export class UpdateAssetHistoryItem {
-  currency_code: string;
+export class UpdatePortfolioInfo {
+  @ApiProperty({
+    description: '포트폴리오 ID',
+    example: 1,
+  })
   portfolio_id: number;
+
+  @ApiProperty({
+    description: '포트폴리오 이름',
+    example: '내 포트폴리오',
+  })
+  portfolio_name: string;
+}
+
+export class UpdateCategoryInfo {
+  @ApiProperty({
+    description: '카테고리 ID',
+    example: 3,
+  })
   category_id: number;
+
+  @ApiProperty({
+    description: '카테고리 이름',
+    example: '국내주식',
+  })
   category_name: string;
+}
+
+export class UpdateInstitutionInfo {
+  @ApiProperty({
+    description: '거래소/증권사 ID',
+    example: 1,
+  })
   institution_id: number;
+
+  @ApiProperty({
+    description: '거래소/증권사 이름',
+    example: '키움증권',
+  })
   institution_name: string;
-  asset_id: number;
-  histories: EditedHistory;
+}
+
+export class UpdateCurrencyInfo {
+  @ApiProperty({
+    description: '통화 코드 ID',
+    example: 1,
+  })
+  currency_code_id: number;
+
+  @ApiProperty({
+    description: '통화 코드',
+    example: 'KRW',
+  })
+  currency_code: string;
+}
+
+export class UpdatedHistory {
+  @ApiProperty({
+    description: '거래내역 ID',
+    example: 558,
+  })
+  asset_history_id: number;
+
+  @ApiProperty({
+    description: '거래 타입 ID',
+    example: 2,
+  })
+  asset_history_type_id: number;
+
+  @ApiProperty({
+    description: '거래 타입 이름',
+    example: 'sell',
+  })
+  type_name: string;
+
+  @ApiProperty({
+    description: '거래 수량',
+    example: 20,
+  })
+  quantity: number;
+
+  @ApiProperty({
+    description: '거래 가격',
+    example: 12500,
+  })
+  price: number;
+
+  @ApiProperty({
+    description: '총 거래 금액',
+    example: 250000,
+  })
+  total_amount: number;
+
+  @ApiProperty({
+    description: '거래 일시 (ISO 8601 형식)',
+    example: '2025-01-04T00:00:00Z',
+  })
+  recorded_at: string;
+
+  @ApiProperty({
+    description: '메모',
+    example: null,
+    nullable: true,
+  })
+  memo: string | null;
+
+  @ApiProperty({
+    description: '수정 일시 (ISO 8601 형식)',
+    example: '2025-09-03T12:00:00Z',
+  })
+  updated_at: string;
+}
+
+export class UpdatedAssetHistoryDetail {
+  @ApiProperty({
+    description: '자산 정보',
+    type: UpdateAssetInfo,
+  })
+  asset_info: UpdateAssetInfo;
+
+  @ApiProperty({
+    description: '포트폴리오 정보',
+    type: UpdatePortfolioInfo,
+  })
+  portfolio_info: UpdatePortfolioInfo;
+
+  @ApiProperty({
+    description: '카테고리 정보',
+    type: UpdateCategoryInfo,
+  })
+  category_info: UpdateCategoryInfo;
+
+  @ApiProperty({
+    description: '거래소/증권사 정보',
+    type: UpdateInstitutionInfo,
+  })
+  institution_info: UpdateInstitutionInfo;
+
+  @ApiProperty({
+    description: '통화 정보',
+    type: UpdateCurrencyInfo,
+  })
+  currency_info: UpdateCurrencyInfo;
+
+  @ApiProperty({
+    description: '수정된 거래내역 정보',
+    type: UpdatedHistory,
+  })
+  updated_history: UpdatedHistory;
 }
 
 export class UpdateAssetHistoryResponseDto {
-  @ApiProperty({ description: '응답 성공 여부', example: true })
+  @ApiProperty({
+    description: '요청 성공 여부',
+    example: true,
+  })
   success: boolean;
 
   @ApiProperty({
     description: '응답 메시지',
-    example: 'Asset history updated successfully.',
+    example: '거래내역이 성공적으로 수정되었습니다',
   })
   message: string;
 
   @ApiProperty({
-    description: '수정된 거래내역 정보',
-    type: UpdateAssetHistoryItem,
-    example: {
-      currency_code: 'KRW',
-      portfolio_id: 1,
-      category_id: 1,
-      category_name: '카테고리 1',
-      institution_id: 1,
-      institution_name: '키움증권',
-      asset_id: 1,
-      histories: {
-        asset_history_id: 1,
-        type: 'buy',
-        quantity: 100,
-        price: 10000,
-        total: 1000000,
-        recorded_at: '2021-01-01',
-        memo: '거래 메모',
-      },
-    },
+    description: '수정된 거래내역 상세 정보',
+    type: UpdatedAssetHistoryDetail,
   })
-  data: UpdateAssetHistoryItem;
+  data: UpdatedAssetHistoryDetail;
 }

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -14,13 +14,11 @@ import {
   ApiCommonErrorResponses,
   ApiCommonErrorResponsesWithNotFound,
   ApiPortfolioParam,
-  ApiHistoryParams,
   ApiGetAllPortfolioResponse,
   ApiCreatePortfolio,
   ApiDeletePortfolioResponse,
   ApiUpdatePortfolio,
   ApiGetPortfolioSummaryResponse,
-  ApiUpdateAssetHistory,
 } from 'src/common/swagger';
 
 import {
@@ -31,9 +29,6 @@ import {
   GetAllPortfolioResponseDto,
   GetPortfolioSummaryParamDto,
   GetPortfolioSummaryResponseDto,
-  UpdateAssetHistoryParamsDto,
-  UpdateAssetHistoryRequestDto,
-  UpdateAssetHistoryResponseDto,
   UpdatePortfolioRequestDto,
   UpdatePortfolioResponseDto,
 } from '../dto';
@@ -118,41 +113,5 @@ export class PortfolioController {
       Number(getPortfolioSummaryParamDto.portfolio_id),
       user.id,
     );
-  }
-
-  @Put(
-    ':portfolio_id/categories/:category_id/assets/:asset_id/histories/:history_id',
-  )
-  @ApiOperation({ summary: '거래내역 수정' })
-  @ApiHistoryParams()
-  @ApiUpdateAssetHistory()
-  @ApiCommonErrorResponsesWithNotFound()
-  async updateAssetHistory(
-    @Param() updateAssetHistoryParamsDto: UpdateAssetHistoryParamsDto,
-    @Body() updateAssetHistoryRequestDto: UpdateAssetHistoryRequestDto,
-  ): Promise<UpdateAssetHistoryResponseDto> {
-    const mockData: UpdateAssetHistoryResponseDto = {
-      success: true,
-      message: 'Transaction histories retrieved successfully.',
-      data: {
-        currency_code: 'KRW',
-        portfolio_id: 1,
-        category_id: 3,
-        category_name: '국내주식',
-        institution_id: 1,
-        institution_name: '키움증권',
-        asset_id: 102,
-        histories: {
-          asset_history_id: 558,
-          type: 'sell',
-          quantity: 20,
-          price: 12500,
-          total: 250000,
-          recorded_at: '2025-01-04',
-          memo: undefined,
-        },
-      },
-    };
-    return mockData;
   }
 }


### PR DESCRIPTION
### ✨ 구현 내용
- **PUT** `/api/portfolios/{portfolio_id}/categories/{category_id}/assets/{asset_id}/histories/{history_id}` API 추가
- 거래내역 수정 시 UserAsset 수량 자동 재계산
- 기관/통화 정보 변경 지원
- 구조화된 응답 데이터 제공

### 💡 주요 기능
- 거래내역 존재 여부 및 소유권 검증
- 복잡한 수량 변화량 계산 (매수/매도 타입 변경 고려)
- 트랜잭션을 통한 데이터 일관성 보장
- 체계적인 에러 핸들링

### 📋 변경사항
- **Controller**: PUT 엔드포인트 추가
- **Service**: 비즈니스 로직 및 검증 로직 구현
- **Repository**: 수량 계산 및 데이터 업데이트 로직
- **DTO**: 요청/응답 구조 개선
