### PR TITLE
Feat#75 환율(스테이블 코인 포함) 스키마 추가와 일일 upsert

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "overseas-master": "ts-node -r tsconfig-paths/register src/database/seeder/overseas/run-overseas-master.ts",
     "seed:code-master": "ts-node -r tsconfig-paths/register src/database/seeder/run-code-master.ts",
     "seed:asset-index": "ts-node -r tsconfig-paths/register src/database/seeder/run-asset-index.ts",
+    "seed:exchange": "ts-node -r tsconfig-paths/register src/database/seeder/run-exchange-seeder.ts",
     "all-seeders": "ts-node -r tsconfig-paths/register src/database/seeder/run-all-seeders.ts"
   },
   "dependencies": {

--- a/src/database/entities/exchange/exchange-rate-daily.entity.ts
+++ b/src/database/entities/exchange/exchange-rate-daily.entity.ts
@@ -1,0 +1,49 @@
+import { Entity, PrimaryGeneratedColumn, Column, Unique } from 'typeorm';
+
+// 환율 일별 스냅샷 엔티티
+// - 목적: USD/KRW, USDT/KRW 등 KRW 기준 일일 환율 저장
+// - 키: (base_currency_id, quote_currency_id, rate_date) 유니크로 멱등 업서트
+// - 주의: numeric은 정밀도 보존을 위해 string으로 다룸
+@Entity('exchange_rate_daily')
+@Unique(['base_currency_id', 'quote_currency_id', 'rate_date'])
+export class ExchangeRateDaily {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  // 기준통화(USD, USDT) -> currency_code.id
+  @Column({ type: 'int' })
+  base_currency_id: number;
+
+  // 상대통화(KRW) -> currency_code.id
+  @Column({ type: 'int' })
+  quote_currency_id: number;
+
+  // 스냅샷 일자 (Asia/Seoul 기준 YYYY-MM-DD)
+  @Column({ type: 'date' })
+  rate_date: string;
+
+  @Column({ type: 'numeric', precision: 20, scale: 10, nullable: true })
+  open: string | null;
+
+  @Column({ type: 'numeric', precision: 20, scale: 10, nullable: true })
+  high: string | null;
+
+  @Column({ type: 'numeric', precision: 20, scale: 10, nullable: true })
+  low: string | null;
+
+  @Column({ type: 'numeric', precision: 20, scale: 10 })
+  close: string;
+
+  // 데이터 출처(KIS, BITHUMB 등)
+  @Column({ type: 'varchar', length: 20, nullable: true })
+  source: string | null;
+
+  // 수집 시각
+  @Column({ type: 'timestamptz', nullable: true })
+  fetched_at: Date | null;
+
+  // 원본 API 응답 저장
+  @Column({ type: 'jsonb', nullable: true })
+  payload: Record<string, any> | null;
+}
+

--- a/src/database/seeder/exchange/exchange.seeder.ts
+++ b/src/database/seeder/exchange/exchange.seeder.ts
@@ -1,0 +1,265 @@
+import { Injectable } from '@nestjs/common';
+import axios from 'axios';
+import { DataSource } from 'typeorm';
+import { CurrencyCode } from 'src/database/entities/code/currency-code.entity';
+import { ExchangeRateDaily } from 'src/database/entities/exchange/exchange-rate-daily.entity';
+import { getKisAccessToken } from '../token/kis-token';
+
+type RateRow = {
+  rate_date: string; // YYYY-MM-DD (Asia/Seoul)
+  open: string | null;
+  high: string | null;
+  low: string | null;
+  close: string; // required
+  source: string; // 'BITHUMB' | 'KIS'
+  payload?: any;
+};
+
+@Injectable()
+export class ExchangeSeeder {
+  constructor(private readonly dataSource: DataSource) {}
+
+  // KST 기준 날짜 문자열(YYYY-MM-DD) 생성
+  private toSeoulDate(d: Date): string {
+    return new Date(d.toLocaleString('en-US', { timeZone: 'Asia/Seoul' }))
+      .toISOString()
+      .slice(0, 10);
+  }
+
+  // 타임스탬프(ms) → KST 날짜 문자열
+  private seoulDateFromTs(tsMs: number): string {
+    return this.toSeoulDate(new Date(tsMs));
+  }
+
+  // 통화 코드 → currency_code.id 조회 (없으면 에러)
+  private async resolveCurrencyId(code: string): Promise<number> {
+    const repo = this.dataSource.getRepository(CurrencyCode);
+    const row = await repo.findOne({ where: { currency_code: code } });
+    if (!row) throw new Error(`CurrencyCode not found for ${code}`);
+    return row.id;
+  }
+
+  // 단순 TypeORM upsert 사용 (가독성 우선)
+  private async upsertDaily(
+    baseCurrencyId: number,
+    quoteCurrencyId: number,
+    row: RateRow,
+  ) {
+    const repo = this.dataSource.getRepository(ExchangeRateDaily);
+    await repo.upsert(
+      {
+        base_currency_id: baseCurrencyId,
+        quote_currency_id: quoteCurrencyId,
+        rate_date: row.rate_date,
+        open: row.open,
+        high: row.high,
+        low: row.low,
+        close: row.close,
+        source: row.source,
+        fetched_at: new Date(),
+        payload: row.payload ?? null,
+      },
+      ['base_currency_id', 'quote_currency_id', 'rate_date'],
+    );
+  }
+
+  // Bithumb USDT/KRW - ticker 기반(현재 스냅샷)
+  // 요구사항: 하루 1회 요청으로 day, day-1 모두 업데이트
+  // 구현: ticker에서
+  //  - day: trade_date_kst의 날짜에 opening/high/low/trade_price 매핑
+  //  - day-1: prev_closing_price만 close로 기록 (open/high/low는 null)
+  private async fetchBithumbUsdtKrwDays(): Promise<RateRow[]> {
+    const url = 'https://api.bithumb.com/v1/ticker?markets=KRW-USDT';
+    const res = await axios.get(url, { timeout: 10000 });
+    const arr = res.data;
+    if (!Array.isArray(arr) || arr.length === 0) {
+      throw new Error('Unexpected Bithumb ticker response');
+    }
+    const d = arr[0];
+
+    const tradeDateKst: string = d.trade_date_kst; // e.g., '20250904'
+    const fmt = (yyyymmdd: string) =>
+      `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+    const todayStr = fmt(tradeDateKst);
+
+    // prev day 계산(KST 기준)
+    const y = Number(tradeDateKst.slice(0, 4));
+    const m = Number(tradeDateKst.slice(4, 6)) - 1; // zero-based
+    const day = Number(tradeDateKst.slice(6, 8));
+    const prevDate = new Date(Date.UTC(y, m, day));
+    // Asia/Seoul 기준에서 하루 빼기 → UTC 자정 기준 -1d 후 다시 포맷
+    prevDate.setUTCDate(prevDate.getUTCDate() - 1);
+    const prevStr = this.toSeoulDate(prevDate);
+
+    const rows: RateRow[] = [];
+
+    // 오늘 데이터
+    rows.push({
+      rate_date: todayStr,
+      open: d.opening_price != null ? String(d.opening_price) : null,
+      high: d.high_price != null ? String(d.high_price) : null,
+      low: d.low_price != null ? String(d.low_price) : null,
+      close: String(d.trade_price),
+      source: 'BITHUMB',
+      payload: d,
+    });
+
+    // 전일 종가만 반영 (open/high/low는 정보 없음)
+    if (d.prev_closing_price != null) {
+      rows.push({
+        rate_date: prevStr,
+        open: null,
+        high: null,
+        low: null,
+        close: String(d.prev_closing_price),
+        source: 'BITHUMB',
+        payload: { prev_only: true, base: d },
+      });
+    }
+
+    return rows;
+  }
+
+  // KIS USD/KRW - 어제/오늘 데이터 수집
+  // 요청 URL: https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/inquire-daily-chartprice
+  // - 토큰: getKisAccessToken() 사용
+  // - 헤더: Authorization: Bearer <token>, appkey, appsecret, tr_id(ENV로 주입 권장)
+  // - 파라미터: 종목/통화코드 및 날짜(어제/오늘) — 구체 값은 ENV로 주입
+  //   예) FID_INPUT_ISCD, FID_INPUT_DATE_1, FID_INPUT_DATE_2, FID_PERIOD_DIV_CODE='D' 등
+  // - 응답 매핑: 일봉 배열에서 날짜/시가/고가/저가/종가 필드를 찾아 RateRow로 정규화
+  private async fetchKisUsdKrwDays(): Promise<RateRow[]> {
+    try {
+      const token = await getKisAccessToken();
+      const appkey = process.env.KIS_APP_KEY as string;
+      const appsecret = process.env.KIS_APP_SECRET as string;
+      if (!appkey || !appsecret) throw new Error('KIS keys missing');
+      const trId = process.env.KIS_TR_ID_DAILY_CHART; // 예: FHKST03030100 (실전)
+      const iscd = process.env.KIS_USD_KRW_ISCD; // KIS에서 요구하는 USD/KRW 코드
+      if (!iscd) {
+        throw new Error('KIS_USD_KRW_ISCD is not set (종목/통화 코드 필요)');
+      }
+      if (!trId) {
+        throw new Error('KIS_TR_ID_DAILY_CHART is not set (헤더 tr_id 필수)');
+      }
+
+      const url =
+        'https://openapi.koreainvestment.com:9443/uapi/overseas-price/v1/quotations/inquire-daily-chartprice';
+
+      // 날짜 범위: 어제/오늘 (KST 기준)
+      const today = this.toSeoulDate(new Date()); // YYYY-MM-DD
+      const yesterday = this.toSeoulDate(new Date(Date.now() - 86400000));
+      const ymd = (s: string) => s.replaceAll('-', ''); // YYYYMMDD
+
+      // 기본 파라미터(단순 고정): 환율(X), 일봉(D), 어제~오늘
+      const params: Record<string, any> = {
+        FID_INPUT_ISCD: iscd,
+        FID_INPUT_DATE_1: ymd(yesterday),
+        FID_INPUT_DATE_2: ymd(today),
+        FID_PERIOD_DIV_CODE: 'D',
+        // 환율 조회 구분값: 'X' = 환율 (KIS 사양)
+        FID_COND_MRKT_DIV_CODE: 'X',
+      };
+
+      const headers: Record<string, any> = {
+        // 필수 헤더
+        'content-type': 'application/json; charset=utf-8',
+        authorization: `Bearer ${token}`,
+        appkey,
+        appsecret,
+        tr_id: trId,
+      };
+
+      const resp = await axios.get(url, { params, headers, timeout: 10000 });
+      const j = resp.data;
+      if (j?.rt_cd && j.rt_cd !== '0') {
+        throw new Error(
+          `KIS error rt_cd=${j.rt_cd} msg=${j?.msg1 || j?.msg_cd}`,
+        );
+      }
+
+      // 출력 배열: output2만 사용(단순화)
+      const out = j?.output2;
+
+      if (!out || !Array.isArray(out)) {
+        throw new Error('KIS daily chart response not an array');
+      }
+
+      // 항목 -> RateRow 매핑 (KIS: ovrs_nmix_* 필드 사용)
+      const fmtYmd = (yyyymmdd: string) =>
+        `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+
+      const rowsAll: RateRow[] = out.map((it: any) => {
+        // 날짜: stck_bsop_date (YYYYMMDD)
+        const rawDate: string = it.stck_bsop_date || '';
+        const rateDate = rawDate.length === 8 ? fmtYmd(rawDate) : today;
+
+        // 가격: ovrs_nmix_oprc/hgpr/lwpr/prpr
+        const open = it.ovrs_nmix_oprc ?? null;
+        const high = it.ovrs_nmix_hgpr ?? null;
+        const low = it.ovrs_nmix_lwpr ?? null;
+        const close = it.ovrs_nmix_prpr ?? null;
+
+        if (close == null) {
+          throw new Error('KIS chart item is missing close price');
+        }
+        return {
+          rate_date: rateDate,
+          open: open != null ? String(open) : null,
+          high: high != null ? String(high) : null,
+          low: low != null ? String(low) : null,
+          close: String(close),
+          source: 'KIS',
+          payload: it,
+        } as RateRow;
+      });
+
+      // 어제/오늘만 필터링 (없으면 있는 것만 사용)
+      const set = new Set([yesterday, today]);
+      const rows = rowsAll.filter((r) => set.has(r.rate_date));
+      // 날짜가 명확치 않아 모두 today로 찍혔다면 중복 제거
+      const map = new Map<string, RateRow>();
+      for (const r of rows) map.set(r.rate_date, r);
+      return Array.from(map.values());
+    } catch (e) {
+      console.warn('KIS fetch failed (stub in use):', e);
+      return [];
+    }
+  }
+
+  async run() {
+    console.log('🚀 Exchange Seeder: start');
+
+    // 통화 코드 ID 조회 (DB의 실제 ID 사용 보장)
+    const baseUSD = await this.resolveCurrencyId('USD');
+    const baseUSDT = await this.resolveCurrencyId('USDT');
+    const quoteKRW = await this.resolveCurrencyId('KRW');
+
+    // 1) Bithumb USDT/KRW (어제/오늘)
+    try {
+      const rows = await this.fetchBithumbUsdtKrwDays();
+      for (const row of rows) {
+        await this.upsertDaily(baseUSDT, quoteKRW, row);
+        console.log(
+          `✅ Upsert BITHUMB USDT/KRW ${row.rate_date} close=${row.close}`,
+        );
+      }
+    } catch (e) {
+      console.error('❌ Bithumb USDT/KRW failed:', e);
+    }
+
+    // 2) KIS USD/KRW (어제/오늘)
+    try {
+      const rows = await this.fetchKisUsdKrwDays();
+      for (const row of rows) {
+        await this.upsertDaily(baseUSD, quoteKRW, row);
+        console.log(
+          `✅ Upsert KIS USD/KRW ${row.rate_date} close=${row.close}`,
+        );
+      }
+    } catch (e) {
+      console.error('❌ KIS USD/KRW failed:', e);
+    }
+
+    console.log('✅ Exchange Seeder: done');
+  }
+}

--- a/src/database/seeder/run-all-seeders.ts
+++ b/src/database/seeder/run-all-seeders.ts
@@ -22,6 +22,7 @@ import { OverseasCryptoMarketSeeder } from './overseas/crypto/crypto-market.seed
 import { OverseasCryptoPriceHistorySeeder } from './overseas/crypto/crpyto-price-history.seeder';
 import { CodeMasterSeeder } from './code-master.seeder';
 import { AssetIndexSeeder } from './asset-index.seeder';
+import { ExchangeSeeder } from './exchange/exchange.seeder';
 
 // 지연 함수
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -61,6 +62,7 @@ async function bootstrap() {
     overseasCryptoMaster: app.get(OverseasCryptoMasterSeeder),
     overseasCryptoMarket: app.get(OverseasCryptoMarketSeeder),
     overseasCryptoPriceHistory: app.get(OverseasCryptoPriceHistorySeeder),
+    exchange: app.get(ExchangeSeeder),
   };
 
   console.log('--- All Seeders Start (Sequential Processing) ---');
@@ -69,6 +71,11 @@ async function bootstrap() {
   console.log('0️⃣ Running code master seeder...');
   await runSeeder(seeders.codeMaster, 'Code master seeder');
   console.log('✅ Code master seeder finished.');
+
+  // 7. Exchange Rates (KRW-based FX)
+  console.log('7️⃣ Running exchange rate seeder...');
+  await runSeeder(seeders.exchange, 'Exchange rate seeder');
+  console.log('✅ Exchange rate seeder finished.');
 
   // 1. Master Data
   console.log('1️⃣ Running master data seeders...');

--- a/src/database/seeder/run-exchange-seeder.ts
+++ b/src/database/seeder/run-exchange-seeder.ts
@@ -1,0 +1,23 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from 'src/app.module';
+import { ExchangeSeeder } from './exchange/exchange.seeder';
+
+async function bootstrap() {
+  console.time('Exchange seeding finished in');
+  const app = await NestFactory.createApplicationContext(AppModule);
+
+  try {
+    const seeder = app.get(ExchangeSeeder);
+    await seeder.run();
+    console.log('✅ Exchange seeder finished.');
+  } catch (e) {
+    console.error('❌ Exchange seeder failed:', e);
+    process.exitCode = 1;
+  } finally {
+    await app.close();
+    console.timeEnd('Exchange seeding finished in');
+  }
+}
+
+bootstrap();
+

--- a/src/database/seeder/seeder.module.ts
+++ b/src/database/seeder/seeder.module.ts
@@ -38,6 +38,8 @@ import { MarketRegion } from '../entities/code/market-region.entity';
 import { Asset } from '../entities/asset/asset.entity';
 import { CodeMasterSeeder } from './code-master.seeder';
 import { AssetIndexSeeder } from './asset-index.seeder';
+import { ExchangeRateDaily } from '../entities/exchange/exchange-rate-daily.entity';
+import { ExchangeSeeder } from './exchange/exchange.seeder';
 
 @Module({
   imports: [
@@ -59,6 +61,7 @@ import { AssetIndexSeeder } from './asset-index.seeder';
       InterestType,
       MarketRegion,
       Asset,
+      ExchangeRateDaily,
     ]),
   ],
   providers: [
@@ -84,6 +87,7 @@ import { AssetIndexSeeder } from './asset-index.seeder';
     OverseasCryptoMasterSeeder,
     OverseasCryptoMarketSeeder,
     OverseasCryptoPriceHistorySeeder,
+    ExchangeSeeder,
   ],
   exports: [
     CodeMasterSeeder,
@@ -108,6 +112,7 @@ import { AssetIndexSeeder } from './asset-index.seeder';
     OverseasCryptoMasterSeeder,
     OverseasCryptoMarketSeeder,
     OverseasCryptoPriceHistorySeeder,
+    ExchangeSeeder,
   ],
 })
 export class SeederModule {}

--- a/src/database/seeder/token/kis-token.ts
+++ b/src/database/seeder/token/kis-token.ts
@@ -1,40 +1,64 @@
-// src/database/seeder/token/kis-token.ts
 import axios from 'axios';
 import Redis from 'ioredis';
 import * as dotenv from 'dotenv';
 
 dotenv.config();
 
-const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+// 주의: 기존 kis-token.ts는 임포트 시 즉시 실행 코드를 포함하므로, seeder에서는 이 유틸을 사용하세요.
+// 사용처: getKisAccessToken() → Bearer 토큰 문자열 반환
+
+let redis: Redis | null = null;
+try {
+  if (process.env.REDIS_URL) {
+    redis = new Redis(process.env.REDIS_URL);
+  }
+} catch (e) {
+  // Redis 연결 실패는 치명적이지 않으므로 무시(로그만)
+  console.warn('WARN: Redis init failed for KIS token cache:', e);
+}
 
 export async function getKisAccessToken(): Promise<string> {
-  // 1. Redis에서 토큰 조회
-  const cached = await redis.get('kis:access_token');
-  if (cached) {
-    console.log('Redis에서 토큰 재사용');
-    return cached;
+  const cacheKey = 'kis:access_token';
+
+  // 1) Redis 캐시 조회
+  if (redis) {
+    try {
+      const cached = await redis.get(cacheKey);
+      if (cached) return cached;
+    } catch (e) {
+      console.warn('WARN: Redis get failed for KIS token:', e);
+    }
   }
 
-  // 2. 없으면 KIS API로 토큰 발급
+  // 2) 토큰 발급
+  const appkey = process.env.KIS_APP_KEY;
+  const appsecret = process.env.KIS_APP_SECRET;
+  if (!appkey || !appsecret) {
+    throw new Error('KIS_APP_KEY/KIS_APP_SECRET is not set');
+  }
+
   const res = await axios.post(
     'https://openapi.koreainvestment.com:9443/oauth2/tokenP',
     {
       grant_type: 'client_credentials',
-      appkey: process.env.KIS_APP_KEY,
-      appsecret: process.env.KIS_APP_SECRET,
+      appkey,
+      appsecret,
     },
+    { timeout: 10000 },
   );
-  const token = res.data.access_token;
-  const expiresIn = res.data.expires_in || 86340; // 만료시간(초), 24시간
 
-  // 3. Redis에 저장 (만료시간 설정)
-  await redis.set('kis:access_token', token, 'EX', expiresIn - 60); // 만료 1분 전 자동 삭제
-  console.log('KIS 토큰 발급 및 Redis 저장');
+  const token: string = res.data?.access_token;
+  const expiresIn: number = res.data?.expires_in || 86340; // 초 단위
+  if (!token) throw new Error('Failed to retrieve KIS access token');
+
+  // 3) 캐시 저장
+  if (redis) {
+    try {
+      await redis.set(cacheKey, token, 'EX', Math.max(60, expiresIn - 60));
+    } catch (e) {
+      console.warn('WARN: Redis set failed for KIS token:', e);
+    }
+  }
+
   return token;
 }
-
-// 테스트 실행
-// getKisAccessToken().then((token) => {
-//   console.log('토큰:', token);
-//   process.exit(0);
-// });


### PR DESCRIPTION
## ✨ 주요 변경사항

### 1. 주요 기능

- KRW 기준 환율 일일 수집·업서트(USDT/KRW from Bithumb, USD/KRW from KIS)
- 하루 1회 실행으로 day, day-1 두 날짜 갱신
- 시더 단독 실행 및 전체 시더(run-all) 통합

### 2. 구현 내용

- Entity: exchange_rate_daily 추가
    - 키: (base_currency_id, quote_currency_id, rate_date) 유니크
    - 컬럼: open/high/low/close, source, fetched_at, payload
- Seeder: ExchangeSeeder 추가
    - Bithumb: GET /v1/ticker?markets=KRW-USDT → day/day-1 매핑
    - KIS: inquire-daily-chartprice(output2) → stck_bsop_date + ovrs_nmix_* 매핑
    - TypeORM repository.upsert로 멱등 처리
- 통합
    - SeederModule 등록, run-all-seeders.ts에 환율 시더 추가
    - 단독 실행: npm run seed:exchange

## ✅ 체크리스트

- [x] 데이터베이스 작업(엔티티/스키마)
- [x] 시더 로직 구현 및 정규화 매핑
- [x] 멱등 업서트 처리(TypeORM upsert)
- [x] 실행 스크립트 및 모듈 통합
- [x] 오류 로깅(KIS rt_cd, msg1)

## 🔒 보안

- KIS 인증: authorization(Bearer), appkey, appsecret, tr_id(FHKST03030100 등)
- 환경변수 사용: KIS_APP_KEY, KIS_APP_SECRET, KIS_TR_ID_DAILY_CHART, KIS_USD_KRW_ISCD=FX@KRW
- 비밀키는 .env/환경 시크릿으로 관리

실행 가이드

- 단독 실행: npm run seed:exchange
- 전체 시더: npm run all-seeders (마지막 단계에 환율 포함)