### PR TITLE
Feat#73 전역 JWT 가드 적용 및 인증 일관화

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,8 @@ import { FavoriteModule } from './modules/favorite/favorite.module';
 import { InvestmentModule } from './modules/investment/investment.module';
 import { UserModule } from './modules/user/user.module';
 import { PortfolioModule } from './modules/portfolio/portfolio.module';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './modules/auth/guards/jwt-auth.guard';
 
 @Module({
   imports: [
@@ -24,6 +26,6 @@ import { PortfolioModule } from './modules/portfolio/portfolio.module';
     UserModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, { provide: APP_GUARD, useClass: JwtAuthGuard }],
 })
 export class AppModule {}

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -31,7 +31,8 @@ import {
 import { ErrorResponseDto } from 'src/common/swagger/dto/error-response.dto';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 import { User } from './decorators/user.decorator';
-import { JwtAuthGuard, RefreshGuard } from './guards';
+import { RefreshGuard } from './guards';
+import { Public } from './decorators/public.decorator';
 
 const COOKIE_OPTIONS = {
   httpOnly: false, // 개발자 도구에서 쿠키 확인 가능
@@ -48,6 +49,7 @@ export class AuthController {
 
   constructor(private readonly authService: AuthService) {}
 
+  @Public()
   @Post('refresh')
   @ApiOperation({ summary: '액세스 토큰 갱신' })
   @ApiRefreshResponse()
@@ -88,7 +90,6 @@ export class AuthController {
   }
 
   @Post('logout')
-  @UseGuards(JwtAuthGuard)
   @ApiOperation({ summary: '로그아웃' })
   @ApiLogoutResponse()
   @ApiCommonErrorResponses()
@@ -127,6 +128,7 @@ export class AuthController {
     }
   }
 
+  @Public()
   @Post(':provider')
   @ApiOperation({ summary: 'Google 토큰 검증 및 로그인' })
   @ApiLoginRequest()

--- a/src/modules/favorite/favorite-asset.controller.ts
+++ b/src/modules/favorite/favorite-asset.controller.ts
@@ -38,7 +38,6 @@ import {
   ApiDeleteFavoriteAssetResponse,
   ApiUpdateFavoriteAsset,
 } from 'src/common/swagger';
-import { JwtAuthGuard } from '../auth/guards';
 import { User } from '../auth/decorators/user.decorator';
 
 @ApiTags('favorites')
@@ -64,7 +63,6 @@ export class FavoriteAssetController {
   })
   @ApiGetFavoriteAssetsResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async getFavoriteAssets(
     @Param() getFavoriteAssetsParamDto: GetFavoriteAssetsParamDto,
     @Query() getFavoriteAssetsQueryDto: GetFavoriteAssetsQueryDto,
@@ -83,7 +81,6 @@ export class FavoriteAssetController {
   @ApiFavoriteFolderParam()
   @ApiCreateFavoriteAssetResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async createFavoriteAsset(
     @Param() createFavoriteAssetParamDto: CreateFavoriteAssetParamDto,
     @Body() createFavoriteAssetBodyDto: CreateFavoriteAssetBodyDto,
@@ -102,7 +99,6 @@ export class FavoriteAssetController {
   @ApiFavoriteAssetParams()
   @ApiDeleteFavoriteAssetResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async deleteFavoriteAsset(
     @Param() deleteFavoriteAssetParamDto: DeleteFavoriteAssetParamDto,
     @User() user: any,
@@ -119,7 +115,6 @@ export class FavoriteAssetController {
   @ApiFavoriteFolderParam()
   @ApiUpdateFavoriteAsset()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async updateFavoriteAsset(
     @Param() updateFavoriteAssetParamDto: UpdateFavoriteAssetParamsDto,
     @Body() updateFavoriteAssetBodyDto: UpdateFavoriteAssetBodyDto,

--- a/src/modules/favorite/favorite-folder.controller.ts
+++ b/src/modules/favorite/favorite-folder.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   Post,
   Put,
-  UseGuards,
 } from '@nestjs/common';
 import { FavoriteFolderService } from './favorite-folder.service';
 import { ApiOperation, ApiTags, ApiBearerAuth } from '@nestjs/swagger';
@@ -27,7 +26,6 @@ import {
   ApiDeleteFavoriteFolderResponse,
   ApiUpdateFavoriteFolderResponse,
 } from 'src/common/swagger';
-import { JwtAuthGuard } from '../auth/guards';
 import { User } from '../auth/decorators/user.decorator';
 
 @ApiTags('favorites')
@@ -40,7 +38,6 @@ export class FavoriteFolderController {
   @ApiOperation({ summary: '관심종목 폴더 목록 조회' })
   @ApiGetFavoriteFoldersResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async getFavoriteFolders(
     @User() user: any,
   ): Promise<GetFavoriteFoldersResponseDto> {
@@ -51,7 +48,6 @@ export class FavoriteFolderController {
   @ApiOperation({ summary: '관심종목 폴더 생성' })
   @ApiCreateFavoriteFolderResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async createFavoriteFolder(
     @Body() createFavoriteFolderDto: CreateFavoriteFolderDto,
     @User() user: any,
@@ -66,7 +62,6 @@ export class FavoriteFolderController {
   @ApiOperation({ summary: '관심종목 폴더 삭제' })
   @ApiDeleteFavoriteFolderResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async deleteFavoriteFolder(
     @Param() deleteFavoriteFolderParamDto: DeleteFavoriteFolderParamDto,
     @User() user: any,
@@ -81,7 +76,6 @@ export class FavoriteFolderController {
   @ApiOperation({ summary: '관심종목 폴더 수정' })
   @ApiUpdateFavoriteFolderResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async updateFavoriteFolder(
     @Body() updateFavoriteFolderBodyDto: UpdateFavoriteFolderBodyDto,
     @User() user: any,

--- a/src/modules/portfolio/asset-history/asset-history.controller.ts
+++ b/src/modules/portfolio/asset-history/asset-history.controller.ts
@@ -7,7 +7,6 @@ import {
   Post,
   Put,
   Query,
-  UseGuards,
 } from '@nestjs/common';
 import { AssetHistoryService } from './asset-history.service';
 import { ApiOperation } from '@nestjs/swagger';
@@ -33,7 +32,6 @@ import {
   UpdateAssetHistoryRequestDto,
   UpdateAssetHistoryResponseDto,
 } from '../dto';
-import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
 
 @Controller('portfolios')
@@ -44,7 +42,6 @@ export class AssetHistoryController {
   @ApiOperation({ summary: '자산 거래내역 조회' })
   @ApiCategoryParams()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async getAssetHistories(
     @Param() getAssetHistoryParamDto: GetAssetHistoryParamDto,
     @Query() getAssetHistoryQueryDto: GetAssetHistoryQueryDto,
@@ -64,7 +61,6 @@ export class AssetHistoryController {
   @ApiCategoryParams()
   @ApiCreateAssetHistory()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async createAssetHistory(
     @Param() createAssetHistoryParamDto: CreateAssetHistoryParamDto,
     @Body() createAssetHistoryRequestDto: CreateAssetHistoryRequestDto,
@@ -86,7 +82,6 @@ export class AssetHistoryController {
   @ApiHistoryParams()
   @ApiDeleteAssetHistoryResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async deleteAssetHistory(
     @Param() deleteAssetHistoryParamsDto: DeleteAssetHistoryParamDto,
     @User() user: any,
@@ -107,7 +102,6 @@ export class AssetHistoryController {
   @ApiHistoryParams()
   @ApiUpdateAssetHistory()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async updateAssetHistory(
     @Param() updateAssetHistoryParamsDto: UpdateAssetHistoryParamDto,
     @Body() updateAssetHistoryRequestDto: UpdateAssetHistoryRequestDto,

--- a/src/modules/portfolio/asset/asset.controller.ts
+++ b/src/modules/portfolio/asset/asset.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Delete, Param, UseGuards } from '@nestjs/common';
+import { Controller, Delete, Param } from '@nestjs/common';
 import { AssetService } from './asset.service';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
 import {
@@ -7,7 +7,6 @@ import {
   ApiDeleteAssetResponse,
 } from 'src/common/swagger';
 import { DeleteAssetParamDto, DeleteAssetResponseDto } from '../dto';
-import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
 
 @ApiTags('portfolios')
@@ -21,7 +20,6 @@ export class AssetController {
   @ApiAssetParams()
   @ApiDeleteAssetResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async deleteAsset(
     @Param() deleteAssetParamDto: DeleteAssetParamDto,
     @User() user: any,

--- a/src/modules/portfolio/category/category.controller.ts
+++ b/src/modules/portfolio/category/category.controller.ts
@@ -7,7 +7,6 @@ import {
   Post,
   Put,
   Query,
-  UseGuards,
 } from '@nestjs/common';
 import { CategoryService } from './category.service';
 
@@ -35,7 +34,6 @@ import {
   UpdateCategoryResponseDto,
 } from '../dto';
 import { ApiOperation, ApiQuery } from '@nestjs/swagger';
-import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
 
 @Controller('portfolios/:portfolio_id/categories')
@@ -98,7 +96,6 @@ export class CategoryController {
   @ApiCategoryParams()
   @ApiCreateCategory()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async createCategory(
     @Param() createCategoryParamDto: CreateCategoryParamDto,
     @Body() createCategoryRequestDto: CreateCategoryRequestDto,
@@ -116,7 +113,6 @@ export class CategoryController {
   @ApiCategoryParams()
   @ApiDeleteCategoryResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async deleteCategory(
     @Param() deleteCategoryParamDto: DeleteCategoryParamDto,
     @User() user: any,
@@ -133,7 +129,6 @@ export class CategoryController {
   @ApiCategoryParams()
   @ApiUpdateCategory()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async updateCategory(
     @Param() updateCategoryParamDto: UpdateCategoryParamDto,
     @Body() updateCategoryRequestDto: UpdateCategoryRequestDto,

--- a/src/modules/portfolio/portfolio/portfolio.controller.ts
+++ b/src/modules/portfolio/portfolio/portfolio.controller.ts
@@ -6,7 +6,6 @@ import {
   Param,
   Post,
   Put,
-  UseGuards,
 } from '@nestjs/common';
 import { PortfolioService } from './portfolio.service';
 import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
@@ -32,7 +31,6 @@ import {
   UpdatePortfolioRequestDto,
   UpdatePortfolioResponseDto,
 } from '../dto';
-import { JwtAuthGuard } from 'src/modules/auth/guards';
 import { User } from 'src/modules/auth/decorators/user.decorator';
 
 @ApiTags('portfolios')
@@ -45,7 +43,6 @@ export class PortfolioController {
   @ApiOperation({ summary: '포트폴리오 조회' })
   @ApiGetAllPortfolioResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async getAllPortfolio(
     @User() user: any,
   ): Promise<GetAllPortfolioResponseDto> {
@@ -56,7 +53,6 @@ export class PortfolioController {
   @ApiOperation({ summary: '포트폴리오 생성' })
   @ApiCreatePortfolio()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async createPortfolio(
     @Body() createPortfolioRequestDto: CreatePortfolioRequestDto,
     @User() user: any,
@@ -72,7 +68,6 @@ export class PortfolioController {
   @ApiPortfolioParam()
   @ApiDeletePortfolioResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async deletePortfolio(
     @Param() deletePortfolioParamDto: DeletePortfolioParamDto,
     @User() user: any,
@@ -88,7 +83,6 @@ export class PortfolioController {
   @ApiPortfolioParam()
   @ApiUpdatePortfolio()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async updatePortfolio(
     @Body() updatePortfolioRequestDto: UpdatePortfolioRequestDto,
     @User() user: any,
@@ -104,7 +98,6 @@ export class PortfolioController {
   @ApiPortfolioParam()
   @ApiGetPortfolioSummaryResponse()
   @ApiCommonErrorResponsesWithNotFound()
-  @UseGuards(JwtAuthGuard)
   async getPortfolioSummary(
     @Param() getPortfolioSummaryParamDto: GetPortfolioSummaryParamDto,
     @User() user: any,

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -7,7 +7,6 @@ import {
   HttpStatus,
   Patch,
   Res,
-  UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
 import { UserService } from './user.service';
@@ -26,7 +25,6 @@ import {
   UpdateNicknameResponseDto,
 } from './dto';
 import { User } from '../auth/decorators/user.decorator';
-import { JwtAuthGuard } from '../auth/guards';
 import { ErrorResponseUtil } from 'src/common/utils/error-response.util';
 
 @ApiTags('user')
@@ -39,7 +37,6 @@ export class UserController {
   @ApiOperation({ summary: '사용자 닉네임 수정' })
   @ApiUpdateNicknameResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async updateNickname(
     @User() user: any,
     @Body() updateNicknameRequestDto: UpdateNicknameRequestDto,
@@ -60,7 +57,6 @@ export class UserController {
   @ApiOperation({ summary: '사용자 정보 조회' })
   @ApiGetUserResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async getUser(@User() user: any): Promise<GetUserResponseDto> {
     return await this.userService.getUser(user.id);
   }
@@ -69,7 +65,6 @@ export class UserController {
   @ApiOperation({ summary: '사용자 탈퇴' })
   @ApiDeleteUserResponse()
   @ApiCommonErrorResponses()
-  @UseGuards(JwtAuthGuard)
   async deleteUser(
     @User() user: any,
     @Body() deleteUserRequestDto: DeleteUserRequestDto,


### PR DESCRIPTION
## ✨ 주요 변경사항

### 1. 주요 기능

- 전역 JwtAuthGuard를 APP_GUARD로 적용해 보호 API 인증 일관화
- 공개 엔드포인트는 @Public()로 명시(로그인/리프레시)
- 컨트롤러 메서드 단위의 중복 @UseGuards(JwtAuthGuard) 제거

### 2. 구현 내용

- App 레벨
    - src/app.module.ts: APP_GUARD로 JwtAuthGuard 등록
- Auth
    - src/modules/auth/auth.controller.ts:
    - `POST /auth/:provider` → `@Public()` 적용
    - `POST /auth/refresh` → `@Public()` + `RefreshGuard` 유지
    - 필요 시 `logout`의 개별 가드 제거(전역 가드 처리)
- Favorite/Portfolio/User
    - 각 컨트롤러에서 메서드 단위 @UseGuards(JwtAuthGuard) 제거
    - 불필요한 JwtAuthGuard import 정리

## ✅ 체크리스트

- [x] APP_GUARD로 전역 JWT 가드 등록
- [x] 공개 엔드포인트에 @Public() 적용
- [x] favorite/portfolio/user 컨트롤러의 중복 가드 제거
- [x] 빌드 및 기본 회귀 테스트 통과
- [x] 인증/비인증 접근 동작 확인

## 🔒 보안

- 기본값: 모든 API는 전역 가드로 보호(JWT 필요)
- 예외: @Public() 명시 엔드포인트(로그인/리프레시)만 비인증 허용
- 위험요소: 추가 공개 엔드포인트가 생길 경우 @Public() 누락 방지 필요