### PR TITLE
Feat#89 예수금 거래내역 조회 구현

### DIFF
--- a/codex/TodayTodo.mdc
+++ b/codex/TodayTodo.mdc
@@ -111,8 +111,8 @@
 - [ ] T1 DB 마이그레이션: balances/transactions 스키마
 - [ ] T2 Cash 도메인 레이어(서비스/리포지토리)
 - [x] T3 API(POST): 예수금 내역 생성(일반/환전) — 구현됨
-- [ ] T4 API(GET): 기관별 예수금 조회 — Next
-- [ ] T5 API(GET): 예수금 상세 이력 조회
+- [x] T4 API(GET): 기관별 예수금 조회 — 구현됨
+- [ ] T5 API(GET): 예수금 상세 이력 조회 — Next
 - [ ] T6 API(DELETE): 예수금 내역 삭제(단건/환전 그룹)
 - [ ] T7 API(PUT): 예수금 내역 수정(일반)
 - [ ] T8 Integration: 매수/매도와 예수금 자동 연동

--- a/src/modules/portfolio/cash/cash.controller.ts
+++ b/src/modules/portfolio/cash/cash.controller.ts
@@ -44,7 +44,7 @@ import { ApiTags } from '@nestjs/swagger';
 export class CashController {
   constructor(private readonly cashService: CashService) {}
 
-  // TODO 기관별 예수금 조회
+  // 기관별 예수금 조회
   @Get('/cash/balances')
   async getCashBalances(
     @Param() getCashBalancesParamDto: GetCashBalancesParamDto,
@@ -71,10 +71,12 @@ export class CashController {
   async getCashTransactions(
     @Param() getCashTransactionsParamDto: GetCashTransactionsParamDto,
     @Query() getCashTransactionsQueryDto: GetCashTransactionsQueryDto,
+    @User() user: any,
   ): Promise<GetCashTransactionsResponseDto> {
     return this.cashService.getCashTransactions(
       getCashTransactionsParamDto,
       getCashTransactionsQueryDto,
+      user.id,
     );
   }
 

--- a/src/modules/portfolio/cash/cash.repository.ts
+++ b/src/modules/portfolio/cash/cash.repository.ts
@@ -25,6 +25,7 @@ import { CurrencyCode } from 'src/database/entities/code/currency-code.entity';
 import { PortfolioInstitutionBalance } from 'src/database/entities/account/portfolio-institution-balance.entity';
 import { BalancesSortBy } from '../dto/enum/balances-sortby.enum';
 import { SortOrder } from '../dto/enum/sort-order.enum';
+import { CashSortBy } from '../dto/enum/cash-sortby.enum';
 
 @Injectable()
 export class CashRepository {
@@ -87,7 +88,91 @@ export class CashRepository {
     paramDto: GetCashTransactionsParamDto,
     queryDto: GetCashTransactionsQueryDto,
   ) {
-    return this.dataSource.getRepository(CashTransaction).find();
+    const { portfolio_id, institution_id } = paramDto;
+
+    const pageNumber = Math.max(1, Number(queryDto.page) || 1);
+    const limitNumber = Math.min(100, Number(queryDto.limit) || 20);
+    const skip = (pageNumber - 1) * limitNumber;
+
+    const sortBy = queryDto.sortBy ?? CashSortBy.RECORDED_AT;
+    const order = (queryDto.order ?? SortOrder.DESC).toUpperCase() as
+      | 'ASC'
+      | 'DESC';
+
+    const qb = this.dataSource
+      .getRepository(CashTransaction)
+      .createQueryBuilder('ct')
+      .leftJoinAndSelect('ct.institution', 'i')
+      .leftJoinAndSelect('ct.currency_code', 'c')
+      .where('ct.portfolio_id = :portfolio_id', { portfolio_id });
+
+    this.applyTxFilters(qb, {
+      institution_id,
+      currency_code_id: queryDto.currency_code_id,
+      from: queryDto.from,
+      to: queryDto.to,
+      type: queryDto.type,
+    });
+
+    const sortColumn =
+      sortBy === CashSortBy.AMOUNT ? 'ct.amount' : 'ct.recorded_at';
+
+    qb.orderBy(sortColumn, order).addOrderBy('ct.id', 'DESC');
+
+    // 페이지네이션 적용
+    qb.skip(skip).take(limitNumber);
+
+    // 총 거래내역 수 조회, clone(): 원본 쿼리빌더 복제 , orderBy(): 정렬 조건 제거, skip(undefined).take(undefined): 페이지네이션 제거,
+    const countQb = qb.clone().orderBy().skip(undefined).take(undefined);
+
+    // 거래내역 조회, getMany(): 페이지네이션 적용, getCount(): 총 거래내역 수 조회
+    const [transactions, totalCount] = await Promise.all([
+      qb.getMany(),
+      countQb.getCount(),
+    ]);
+
+    return {
+      items: transactions,
+      pagination: totalCount,
+    };
+  }
+
+  // 내부 헬퍼: 필터 공통 적용
+  private applyTxFilters(
+    qb: import('typeorm').SelectQueryBuilder<CashTransaction>,
+    opts: {
+      institution_id?: number;
+      currency_code_id?: number;
+      from?: string;
+      to?: string;
+      type?: string;
+    },
+  ) {
+    const { institution_id, currency_code_id, from, to, type } = opts;
+
+    if (institution_id) {
+      qb.andWhere('ct.institution_id = :institution_id', { institution_id });
+    }
+    if (currency_code_id) {
+      qb.andWhere('ct.currency_code_id = :currency_code_id', {
+        currency_code_id,
+      });
+    }
+    if (from) {
+      qb.andWhere('ct.recorded_at >= :from', { from: new Date(from) });
+    }
+    if (to) {
+      qb.andWhere('ct.recorded_at <= :to', { to: new Date(to) });
+    }
+    if (type) {
+      if (type === 'exchange') {
+        qb.andWhere('ct.type IN (:...exTypes)', {
+          exTypes: ['exchange_out', 'exchange_in'],
+        });
+      } else {
+        qb.andWhere('ct.type = :type', { type });
+      }
+    }
   }
 
   async createCashTransaction(

--- a/src/modules/portfolio/cash/cash.service.ts
+++ b/src/modules/portfolio/cash/cash.service.ts
@@ -12,11 +12,7 @@ import { DeleteCashTransactionQueryDto } from '../dto/requests/cash/delete-cash-
 import { UpdateCashTransactionParamDto } from '../dto/requests/cash/update-cash-transaction.dto';
 import { UpdateCashTransactionBodyDto } from '../dto/requests/cash/update-cash-transaction.dto';
 import { GetCashBalancesResponseDto } from '../dto/responses/cash/get-cash-balances.dto';
-import {
-  GetCashTransactionsResponseDto,
-  CashTransactionItem,
-  PaginationMeta,
-} from '../dto/responses/cash/get-cash-transactions.dto';
+import { GetCashTransactionsResponseDto } from '../dto/responses/cash/get-cash-transactions.dto';
 import { CreateCashTransactionResponseDto } from '../dto/responses/cash/create-cash-transaction.dto';
 import { DeleteCashTransactionResponseDto } from '../dto/responses/cash/delete-cash-transaction.dto';
 import { UpdateCashTransactionResponseDto } from '../dto/responses/cash/update-cash-transaction.dto';
@@ -24,6 +20,7 @@ import { CashTransactionType } from '../dto/enum/cash-transaction-type.enum';
 import { PortfolioValidator } from '../lib/portfolio-validator';
 import { CashCreateType } from '../dto/enum/cash-create-type.enum';
 import { BalancesSortBy } from '../dto/enum/balances-sortby.enum';
+import { CashSortBy } from '../dto/enum/cash-sortby.enum';
 
 @Injectable()
 export class CashService {
@@ -32,7 +29,7 @@ export class CashService {
     private readonly portfolioValidator: PortfolioValidator,
   ) {}
 
-  // TODO 기관별 예수금 조회
+  // 기관별 예수금 조회
   async getCashBalances(
     paramDto: GetCashBalancesParamDto,
     queryDto: GetCashBalancesQueryDto,
@@ -97,46 +94,72 @@ export class CashService {
   async getCashTransactions(
     paramDto: GetCashTransactionsParamDto,
     queryDto: GetCashTransactionsQueryDto,
+    userId: string,
   ): Promise<GetCashTransactionsResponseDto> {
-    const items = await this.cashRepository.getCashTransactions(
-      paramDto,
-      queryDto,
-    );
-    const pagination: PaginationMeta = {
-      current_page: queryDto.page ?? 1,
-      limit: queryDto.limit ?? 20,
-      total_items: Array.isArray(items) ? items.length : 0,
-      total_pages: 1,
-    };
-    return {
-      success: true,
-      message: 'Cash transactions retrieved successfully.',
-      data: {
-        portfolio_id: paramDto.portfolio_id,
-        institution_id: paramDto.institution_id,
-        sorted_by: (queryDto?.sortBy as any) ?? 'recorded_at',
-        filters: {
-          type: queryDto?.type,
-          currency_code_id: queryDto?.currency_code_id,
-          from: queryDto?.from,
-          to: queryDto?.to,
+    try {
+      // 소유권 검증
+      const { portfolio, institution } =
+        await this.portfolioValidator.validatePortfolioAndFindUserAssetForCash(
+          paramDto.portfolio_id,
+          paramDto.institution_id,
+          userId,
+        );
+
+      if (!portfolio || !institution) {
+        throw new HttpException(
+          ErrorResponseUtil.notFound('Portfolio or institution not found'),
+          HttpStatus.NOT_FOUND,
+        );
+      }
+
+      // 예수금 상세 조회
+      const result = await this.cashRepository.getCashTransactions(
+        paramDto,
+        queryDto,
+      );
+
+      // 반환
+      return {
+        success: true,
+        message: 'Cash transactions retrieved successfully.',
+        data: {
+          portfolio_id: paramDto.portfolio_id,
+          institution_id: paramDto.institution_id,
+          sorted_by: queryDto?.sortBy ?? CashSortBy.RECORDED_AT,
+          filters: {
+            type: queryDto?.type ?? undefined,
+            currency_code_id: queryDto?.currency_code_id ?? undefined,
+            from: queryDto?.from ?? undefined,
+            to: queryDto?.to ?? undefined,
+          },
+          pagination: {
+            current_page: queryDto?.page ?? 1,
+            limit: queryDto?.limit ?? 20,
+            total_items: result.pagination,
+            total_pages: Math.ceil(result.pagination / (queryDto?.limit ?? 20)),
+          },
+          items: result.items.map((t) => ({
+            cash_transaction_id: t.id,
+            type: t.type as unknown as CashTransactionType,
+            amount: parseFloat(t.amount),
+            currency_code_id: t.currency_code_id,
+            currency_code: t.currency_code.currency_code,
+            symbol: t.currency_code?.symbol ?? '',
+            rate: (t as any).rate,
+            recorded_at: t.recorded_at.toISOString(),
+            memo: t.memo ?? null,
+            exchange_group_id: t.exchange_group_id ?? null,
+          })),
         },
-        pagination,
-        items: (items as any[]).map(
-          () =>
-            ({
-              cash_transaction_id: 0,
-              type: CashTransactionType.DEPOSIT,
-              amount: 0,
-              currency_code_id: 0,
-              currency_code: '',
-              recorded_at: new Date().toISOString(),
-              memo: null,
-              exchange_group_id: null,
-            }) as CashTransactionItem,
+      };
+    } catch (error) {
+      throw new HttpException(
+        ErrorResponseUtil.internalServerError(
+          'Failed to get cash transactions',
         ),
-      },
-    };
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 
   // 예수금 내역 추가

--- a/src/modules/portfolio/dto/requests/cash/get-cash-transactions.dto.ts
+++ b/src/modules/portfolio/dto/requests/cash/get-cash-transactions.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsEnum,
   IsInt,
   IsISO8601,
   IsOptional,
   Max,
   Min,
+  IsIn,
+  IsString,
 } from 'class-validator';
 import { CashTransactionType } from '../../enum/cash-transaction-type.enum';
 import { CashSortBy } from '../../enum/cash-sortby.enum';
@@ -31,12 +32,23 @@ export class GetCashTransactionsParamDto {
 
 export class GetCashTransactionsQueryDto {
   @IsOptional()
-  @IsEnum(CashTransactionType)
+  @IsString()
+  @IsIn([
+    'exchange',
+    CashTransactionType.DEPOSIT,
+    CashTransactionType.WITHDRAW,
+    CashTransactionType.FEE,
+    CashTransactionType.TAX,
+    CashTransactionType.DIVIDEND,
+    CashTransactionType.OTHER,
+    CashTransactionType.EXCHANGE_IN,
+    CashTransactionType.EXCHANGE_OUT,
+  ])
   @ApiProperty({
     description: '타입',
     example: CashTransactionType.DEPOSIT,
   })
-  type?: CashTransactionType;
+  type?: CashTransactionType | 'exchange';
 
   @IsOptional()
   @IsInt()
@@ -82,7 +94,7 @@ export class GetCashTransactionsQueryDto {
   limit?: number;
 
   @IsOptional()
-  @IsEnum(CashSortBy)
+  @IsIn([CashSortBy.RECORDED_AT, CashSortBy.AMOUNT])
   @ApiProperty({
     description: '정렬 기준',
     example: CashSortBy.RECORDED_AT,
@@ -90,7 +102,7 @@ export class GetCashTransactionsQueryDto {
   sortBy?: CashSortBy;
 
   @IsOptional()
-  @IsEnum(SortOrder)
+  @IsIn([SortOrder.ASC, SortOrder.DESC])
   @ApiProperty({
     description: '정렬 순서',
     example: SortOrder.ASC,

--- a/src/modules/portfolio/dto/responses/cash/get-cash-transactions.dto.ts
+++ b/src/modules/portfolio/dto/responses/cash/get-cash-transactions.dto.ts
@@ -57,6 +57,18 @@ export class CashTransactionItem {
   currency_code: string;
 
   @ApiProperty({
+    description: '통화 기호',
+    example: '₩',
+  })
+  symbol: string;
+
+  @ApiProperty({
+    description: '환율',
+    example: 1300.123456,
+  })
+  rate: number;
+
+  @ApiProperty({
     description: '기록 일시',
     example: '2021-01-01T00:00:00Z',
   })
@@ -80,7 +92,7 @@ export class CashTransactionsFilters {
     description: '타입',
     example: CashTransactionType.DEPOSIT,
   })
-  type?: CashTransactionType;
+  type?: CashTransactionType | 'exchange';
 
   @ApiProperty({
     description: '통화 코드 ID',


### PR DESCRIPTION
## ✨ 주요 변경사항

- Repository
    - 잔액 조회: institution, currency_code 조인 + 필터/정렬(balance|updated_at|
institution) + 보조정렬 적용
    - 거래내역 조회: 필터(type 별칭 exchange, currency_code_id, from, to), 정렬
(recorded_at|amount), 페이지네이션(page, limit) 구현
    - 중복 조인 별칭(i) 오류 수정
- Service
    - 잔액 응답 매핑: currency_code 코드값 사용(KRW/USD), avg_rate null 보존,
updated_at ISO 문자열
- DTO
    - 요청/응답에 type=exchange 별칭 지원, sortBy/order 검증 강화(@IsIn)
- Docs
    - TodayTodo: T4 완료, T5 Next로 갱신

## ✅ 체크리스트

- [x] 잔액/거래내역 레포지토리 쿼리
- [x] DTO 검증/스키마 정리
- [x] 서비스 매핑 및 에러 처리
- [x] 조인 별칭 오류 수정
- [ ] Swagger 예시/문서 업데이트
- [ ] 유닛/통합 테스트 추가

## 🔒 보안

- JWT 인증 및 포트폴리오 소유권 검증 적용 (balances/transactions)